### PR TITLE
Add mecanum drive layer and input mapping

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
@@ -80,6 +80,7 @@ public class RobotController {
                 return true;
             }
         }
+        layerIter.previous(); // Throw away current layer
         Task task;
         while (true) {
             task = layer.update();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
@@ -170,22 +170,23 @@ public class MecanumDrive implements Layer {
      * Name of the drive motors in the robot configuration.
      */
     private static final WheelProperty<String> DRIVE_MOTOR_NAMES = new WheelProperty<>(
-        "left-front-drive-motor",
-        "right-front-drive-motor",
-        "left-back-drive-motor",
-        "right-back-drive-motor"
+        "left_front_drive",
+        "right_front_drive",
+        "left_back_drive",
+        "right_back_drive"
     );
     /**
      * The radius of the drive wheels in meters.
+     * The current value is measured from the edge, including rollers.
      */
-    private static final double WHEEL_RADIUS = 0.42;
+    private static final double WHEEL_RADIUS = Units.convert(4.25, Units.Distance.CM, Units.Distance.M);
     /**
      * The effective gear ratio of the wheels to the motor drive shafts.
      * Expressed as wheelTeeth / hubGearTeeth, ignoring all intermediate meshing gears as they
      * should cancel out. Differently teethed gears driven by the same axle require more
      * consideration.
      */
-    private static final WheelProperty<Double> GEAR_RATIO = WheelProperty.populate((_key) -> 1.0);
+    private static final WheelProperty<Double> GEAR_RATIO = WheelProperty.populate((_key) -> 20.0);
     /**
      * Half the distance between the driving wheels in meters.
      */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
@@ -12,7 +12,7 @@ import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.mechanism.Wheel;
 import org.firstinspires.ftc.teamcode.task.AxialMovementTask;
 import org.firstinspires.ftc.teamcode.task.LinearMovementTask;
-import org.firstinspires.ftc.teamcode.task.MecanumDriveTask;
+import org.firstinspires.ftc.teamcode.task.HolonomicDriveTask;
 import org.firstinspires.ftc.teamcode.task.TankDriveTask;
 import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.TurnTask;
@@ -287,9 +287,9 @@ public class MecanumDrive implements Layer {
                 castedTask.left,
                 castedTask.right
             )).forEach((key, velocity) -> wheels.get(key).setVelocity(velocity));
-        } else if (task instanceof MecanumDriveTask) {
+        } else if (task instanceof HolonomicDriveTask) {
             isAuto = false;
-            MecanumDriveTask castedTask = (MecanumDriveTask)task;
+            HolonomicDriveTask castedTask = (HolonomicDriveTask)task;
             normalizeVelocities(calculateAlyDeltas(
                 castedTask.axial,
                 castedTask.lateral,

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
@@ -11,6 +11,8 @@ import org.firstinspires.ftc.teamcode.layer.Layer;
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.mechanism.Wheel;
 import org.firstinspires.ftc.teamcode.task.AxialMovementTask;
+import org.firstinspires.ftc.teamcode.task.LinearMovementTask;
+import org.firstinspires.ftc.teamcode.task.MecanumDriveTask;
 import org.firstinspires.ftc.teamcode.task.TankDriveTask;
 import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.TurnTask;
@@ -32,7 +34,7 @@ public class MecanumDrive implements Layer {
             LEFT_FRONT(true, true),
             RIGHT_FRONT(false, true),
             LEFT_BACK(true, false),
-            RIGHT_BACK(false, false)
+            RIGHT_BACK(false, false);
 
             /**
              * Whether the wheel is on the left side of the robot.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
@@ -1,0 +1,281 @@
+package org.firstinspires.ftc.teamcode.layer.drive;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+import org.firstinspires.ftc.teamcode.layer.Layer;
+import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
+import org.firstinspires.ftc.teamcode.mechanism.Wheel;
+import org.firstinspires.ftc.teamcode.task.AxialMovementTask;
+import org.firstinspires.ftc.teamcode.task.TankDriveTask;
+import org.firstinspires.ftc.teamcode.task.Task;
+import org.firstinspires.ftc.teamcode.task.TurnTask;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
+import org.firstinspires.ftc.teamcode.Units;
+
+/**
+ * Drive layer for a robot using four properly-oriented mecanum wheels.
+ */
+public class MecanumDrive implements Layer {
+    /**
+     * Represents a property held by each wheel.
+     */
+    private static class WheelProperty<T> {
+        /**
+         * Denotes a wheel.
+         */
+        private static enum WheelKey {
+            LEFT_FRONT,
+            RIGHT_FRONT,
+            LEFT_BACK,
+            RIGHT_BACK
+        }
+        /**
+         * A never-to-be-changed null WheelProperty used to minimize the number of objects created
+         * by populate.
+         */
+        private static final WheelProperty<Object> NULL_PROP = new WheelProperty<>();
+        /**
+         * The value of the property for the left front wheel.
+         */
+        public T leftFront;
+        /**
+         * The value of the property for the right front wheel.
+         */
+        public T rightFront;
+        /**
+         * The value of the property for the left back wheel.
+         */
+        public T leftBack;
+        /**
+         * The value of the property for the right back wheel.
+         */
+        public T rightBack;
+        /**
+         * Default-constructs a WheelProperty, setting all values to null.
+         */
+        public WheelProperty() {
+            leftFront = null;
+            rightFront = null;
+            leftBack = null;
+            rightBack = null;
+        }
+        /**
+         * Initializes a WheelProperty with values for each wheel..
+         * @param leftFront the value of the property for the left front wheel.
+         * @param rightFront the value of the property for the right front wheel.
+         * @param leftBack the value of the property for the left back wheel.
+         * @param rightBack the value of the property for the right back wheel.
+         */
+        public WheelProperty(T leftFront, T rightFront, T leftBack, T rightBack) {
+            this.leftFront = leftFront;
+            this.rightFront = rightFront;
+            this.leftBack = leftBack;
+            this.rightBack = rightBack;
+        }
+        /**
+         * Creates a WheelProperty by applying a function to each wheel.
+         */
+        public static <R> WheelProperty<R> populate(Function<WheelKey, R> populator) {
+            return NULL_PROP.map((key, _) -> populator.apply(key));
+        }
+        /**
+         * Gets the value of the property for the given wheel.
+         * @param key - the wheel whose value should be retrieved
+         * @return The value of the property for the given wheel.
+         */
+        public T get(WheelKey key) {
+            switch (key) {
+                case WheelKey.LEFT_FRONT:
+                    return leftFront;
+                case WheelKey.RIGHT_FRONT:
+                    return rightFront;
+                case WheelKey.LEFT_BACK:
+                    return leftBack;
+                case WheelKey.RIGHT_BACK:
+                    return rightBack;
+            }
+        }
+        /**
+         * Sets the value of the property for the given wheel.
+         * @param key - the wheel whose value should be set
+         * @param value - the value to set the property to
+         */
+        public void put(WheelKey key, T value) {
+            switch (key) {
+                case WheelKey.LEFT_FRONT:
+                    leftFront = value;
+                case WheelKey.RIGHT_FRONT:
+                    rightFront = value;
+                case WheelKey.LEFT_BACK:
+                    leftBack = value;
+                case WheelKey.RIGHT_BACK:
+                    rightBack = value;
+            }
+        }
+        /**
+         * Calls a function on each of the left wheels' keys and values.
+         * @param callback - the function to call
+         */
+        public void leftForEach(BiConsumer<WheelKey, T> callback) {
+            callback.accept(WheelKey.LEFT_FRONT, leftFront);
+            callback.accept(WheelKey.LEFT_BACK, leftBack);
+        }
+        /**
+         * Calls a function on each of the right wheels' keys and values.
+         * @param callback - the function to call
+         */
+        public void rightForEach(BiConsumer<WheelKey, T> callback) {
+            callback.accept(WheelKey.RIGHT_FRONT, rightFront);
+            callback.accept(WheelKey.RIGHT_BACK, rightBack);
+        }
+        /**
+         * Calls a function on each of the wheels' keys and values.
+         * @param callback - the function to call
+         */
+        public void forEach(BiConsumer<WheelKey, T> callback) {
+            leftForEach(callback);
+            rightForEach(callback);
+        }
+        /**
+         * Returns a new WheelProperty populated with the results of calling a mapper function with
+         * the keys and values of this property.
+         * @param mapper - the function used to map old values to new values
+         */
+        public <R> WheelProperty<R> map(BiFunction<WheelKey, T, R> mapper) {
+            WheelProperty<R> mapped = new WheelProperty<>();
+            forEach((key, old) -> mapped.put(key, mapper.apply(key, old)));
+            return mapped;
+        }
+    }
+    /**
+     * Name of the drive motors in the robot configuration.
+     */
+    private static final WheelProperty<String> DRIVE_MOTOR_NAMES = new WheelProperty<>(
+        "left-front-drive-motor",
+        "right-front-drive-motor",
+        "left-back-drive-motor",
+        "right-back-drive-motor"
+    );
+    /**
+     * The radius of the drive wheels in meters.
+     */
+    private static final double WHEEL_RADIUS = 0.42;
+    /**
+     * The effective gear ratio of the wheels to the motor drive shafts.
+     * Expressed as wheelTeeth / hubGearTeeth, ignoring all intermediate meshing gears as they
+     * should cancel out. Differently teethed gears driven by the same axle require more
+     * consideration.
+     */
+    private static final WheelProperty<Double> GEAR_RATIO = new WheelProperty.populate((_) -> 1.0);
+    /**
+     * Half the distance between the driving wheels in meters.
+     */
+    private static final double WHEEL_SPAN_RADIUS = 0.84;
+    /**
+     * Unitless, experimentally determined constant (ew) measuring lack of friction.
+     * Measures lack of friction between wheels and floor material. Goal delta distances are directly
+     * proportional to this.
+     */
+    private static final double SLIPPING_CONSTANT = 1;
+
+    /**
+     * The robot's wheels.
+     */
+    private final WheelProperty<Wheel> wheels;
+    /**
+     * The position of the wheels at the start of the currently executing task, in meters.
+     */
+    private final WheelProperty<Double> wheelStartPos;
+    /**
+     * The required delta position of the wheels to complete the currently executing task, in
+     * meters.
+     */
+    private final WheelProperty<Double> wheelGoalDeltas;
+    /**
+     * Whether the currently executing task has completed.
+     */
+    private boolean currentTaskDone;
+
+    @Override
+    public void setup(LayerSetupInfo initInfo) {
+        wheels = DRIVE_MOTOR_NAMES.map((key, motorName) -> new Wheel(
+            initInfo.getHardwareMap().get(DcMotor.class, motorName),
+            WHEEL_RADIUS
+        ));
+        wheelStartPos = WheelProperty.populate((_) -> 0);
+        wheelGoalDeltas = WheelProperty.populate((_) -> 0);
+        currentTaskDone = true;
+    }
+
+    @Override
+    public boolean isTaskDone() {
+        return currentTaskDone;
+    }
+
+    @Override
+    public Task update() {
+        WheelProperty<Double> deltas = wheels.map((key, wheel) -> 
+            wheel.getDistance() - wheelStartPos.get(key)
+        );
+        WheelProperty<Boolean> deltaSignsMatch = deltas.map((key, delta) ->
+            (delta < 0) == (wheelGoalDeltas.get(key) < 0)
+        );
+        WheelProperty<Boolean> goalDeltaExceeded = deltas.map((key, delta) ->
+            Math.abs(delta) >= Math.abs(wheelGoalDeltas.get(key))
+        );
+        WheelProperty<Boolean> wheelDone = wheelGoalDeltas.map((key, goalDelta) ->
+            (deltaSignsMatch.get(key) && goalDeltaExceeded.get(key)) || goalDelta == 0
+        );
+
+        boolean isTeleopTask = leftGoalDelta == 0 && rightGoalDelta == 0;
+        currentTaskDone = true;
+        wheelDone.forEach((_, done) -> currentTaskDone = done && currentTaskDone);
+        if (currentTaskDone && !isTeleopTask) {
+            wheels.forEach((_, wheel) -> wheel.setVelocity(0));
+        }
+        // Adaptive velocity control goes here.
+        return null;
+    }
+
+    @Override
+    public void acceptTask(Task task) {
+        currentTaskDone = false;
+        wheels.forEach((key, wheel) -> wheelStartPos.put(key, wheel.getDistance()));
+        double deltaFac = GEAR_RATIO * SLIPPING_CONSTANT;
+        if (task instanceof AxialMovementTask) {
+            AxialMovementTask castedTask = (AxialMovementTask)task;
+            GEAR_RATIO.forEach((key, gearRatio) ->
+                wheelGoalDeltas.put(key, castedTask.distance * gearRatio * SLIPPING_CONSTANT)
+            );
+            wheels.forEach((key, wheel) ->
+                wheel.setVelocity(Math.signum(wheelGoalDeltas.get(key))));
+        } else if (task instanceof TurnTask) {
+            TurnTask castedTask = (TurnTask)task;
+            GEAR_RATIO.leftForEach((key, gearRatio) -> wheelGoalDeltas.put(
+                key,
+                -castedTask.angle * WHEEL_SPAN_RADIUS * gearRatio * SLIPPING_CONSTANT
+            ));
+            GEAR_RATIO.rightForEach((key, gearRatio) -> wheelGoalDeltas.put(
+                key,
+                castedTask.angle * WHEEL_SPAN_RADIUS * gearRatio * SLIPPING_CONSTANT
+            ));
+            wheels.forEach((key, wheel) ->
+                wheel.setVelocity(Math.signum(wheelGoalDeltas.get(key))));
+        } else if (task instanceof TankDriveTask) {
+            // Teleop, set deltas to 0 to pretend we're done
+            wheelGoalDeltas.forEach((key, _) -> wheelGoalDeltas.put(0));
+            TankDriveTask castedTask = (TankDriveTask)task;
+            double maxAbsPower = Math.max(
+                Math.max(Math.abs(castedTask.left), Math.abs(castedTask.right)),
+                1 // Clamp to 1 to prevent upscaling
+            );
+            wheels.leftForEach((_, wheel) -> wheel.setVelocity(castedTask.left / maxAbsPower));
+            wheels.rightForEach((_, wheel) -> wheel.setVelocity(castedTask.right / maxAbsPower));
+        } else {
+            throw new UnsupportedTaskException(this, task);
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/MecanumDrive.java
@@ -310,9 +310,9 @@ public class MecanumDrive implements Layer {
 
     /**
      * Calculates motor deltas from axial, lateral, and yaw given in arbitrary units.
-     * @param axial - axial value
-     * @param lateral - lateral value
-     * @param yaw - yaw value
+     * @param axial - axial value, positive forward
+     * @param lateral - lateral value, positive right
+     * @param yaw - yaw value, positive counterclockwise
      * @return motor deltas calculated for each wheel.
      */
     private WheelProperty<Double> calculateAlyDeltas(double axial, double lateral, double yaw) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
@@ -79,7 +79,6 @@ public class TwoWheelDrive implements Layer {
 
     @Override
     public void setup(LayerSetupInfo initInfo) {
-        // Wheel class has three parameters: motor, radius, and ticks per rotation.
         leftWheel = new Wheel(
             initInfo.getHardwareMap().get(DcMotor.class, LEFT_DRIVE_MOTOR_NAME),
             WHEEL_RADIUS
@@ -148,6 +147,7 @@ public class TwoWheelDrive implements Layer {
             );
             leftWheel.setVelocity(castedTask.left / maxAbsPower);
             rightWheel.setVelocity(castedTask.right / maxAbsPower);
+            return;
         } else {
             throw new UnsupportedTaskException(this, task);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
@@ -19,11 +19,11 @@ public class TwoWheelDrive implements Layer {
     /**
      * Name of the left drive motor in the robot configuration.
      */
-    private static final String LEFT_DRIVE_MOTOR_NAME = "6_spamandeggs";
+    private static final String LEFT_DRIVE_MOTOR_NAME = "left_front_drive";
     /**
      * Name of the right drive motor in the robot configuration.
      */
-    private static final String RIGHT_DRIVE_MOTOR_NAME = "6_spamandeggs";
+    private static final String RIGHT_DRIVE_MOTOR_NAME = "right_front_drive";
     /**
      * The radius of the drive wheels in meters.
      */
@@ -34,7 +34,7 @@ public class TwoWheelDrive implements Layer {
      * should cancel out. Differently teethed gears driven by the same axle require more
      * consideration.
      */
-    private static final double GEAR_RATIO = 1;
+    private static final double GEAR_RATIO = 20; // ticks per rot = 28, should get from config
     /**
      * Half the distance between the driving wheels in meters.
      */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
@@ -22,11 +22,11 @@ public class GamepadInputGenerator extends InputGenerator {
     public Task update() {
         return new GamepadInputTask(
             gamepad0 == null ? null : new GamepadInputTask.GamepadInput(
-                gamepad0.left_stick_x,
+                -gamepad0.left_stick_x,
                 gamepad0.left_stick_y,
                 gamepad0.left_bumper,
                 gamepad0.left_trigger,
-                gamepad0.right_stick_x,
+                -gamepad0.right_stick_x,
                 gamepad0.right_stick_y,
                 gamepad0.right_bumper,
                 gamepad0.right_trigger,
@@ -40,11 +40,11 @@ public class GamepadInputGenerator extends InputGenerator {
                 gamepad0.y
             ),
             gamepad1 == null ? null : new GamepadInputTask.GamepadInput(
-                gamepad1.left_stick_x,
+                -gamepad1.left_stick_x,
                 gamepad1.left_stick_y,
                 gamepad1.left_bumper,
                 gamepad1.left_trigger,
-                gamepad1.right_stick_x,
+                -gamepad1.right_stick_x,
                 gamepad1.right_stick_y,
                 gamepad1.right_bumper,
                 gamepad1.right_trigger,

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/JoystickHoloDriveMapping.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/JoystickHoloDriveMapping.java
@@ -1,0 +1,31 @@
+package org.firstinspires.ftc.teamcode.layer.input.mapping;
+
+import org.firstinspires.ftc.teamcode.layer.FunctionLayer;
+import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
+import org.firstinspires.ftc.teamcode.task.GamepadInputTask;
+import org.firstinspires.ftc.teamcode.task.Task;
+import org.firstinspires.ftc.teamcode.task.HolonomicDriveTask;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
+
+/**
+ * Mapping for gamepad input that uses the left joystick for axial and lateral movement (relative to
+ * the robot) and the x axis of the right joystick to turn a robot using holonomic drive.
+ */
+public class JoystickHoloDriveMapping extends FunctionLayer {
+    @Override
+    public void setup(LayerSetupInfo setupInfo) { }
+
+    @Override
+    public Task map(Task task) {
+        if (task instanceof GamepadInputTask) {
+            GamepadInputTask castedTask = (GamepadInputTask)task;
+            return new HolonomicDriveTask(
+                castedTask.gamepad0.joysticks.left.y,
+                castedTask.gamepad0.joysticks.left.x,
+                -castedTask.gamepad0.joysticks.right.x
+            );
+        } else {
+            throw new UnsupportedTaskException(this, task);
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/GamepadInputTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/GamepadInputTask.java
@@ -7,10 +7,12 @@ public class GamepadInputTask implements Task {
     public static class Joystick {
         /**
          * The horizontal axis of the joystick.
+         * Positive values corrospond to the rightward direction.
          */
         public final float x;
         /**
          * The vertical axis of the joystick.
+         * Positive values corrospond to the upward direction.
          */
         public final float y;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/HolonomicDriveTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/HolonomicDriveTask.java
@@ -1,9 +1,10 @@
 package org.firstinspires.ftc.teamcode.task;
 
 /**
- * Specifies relative accelerations for the axial, lateral, and yaw component of a mecanum drive.
+ * Specifies relative accelerations for the axial, lateral, and yaw component of a holonomic drive
+ * (a drive train that can strafe without turning).
  */
-public class MecanumDriveTask implements Task {
+public class HolonomicDriveTask implements Task {
     /**
      * The relative acceleration to apply in the direction the robot is facing.
      * Positive values indicate forward movement and negative values indicate backward.
@@ -21,13 +22,13 @@ public class MecanumDriveTask implements Task {
      */
     public double yaw;
     /**
-     * Constructs a MecanumDriveTask.
+     * Constructs a HolonomicDriveTask.
      * @param axial - the relative acceleration to apply in the direction the robot is facing.
      * @param lateral - the relative acceleration to apply in the direction perpendicular to the one
      * the robot is facing.
      * @param yaw - the relative acceleration to use to turn the robot.
      */
-    public MecanumDriveTask(double axial, double lateral, double yaw) {
+    public HolonomicDriveTask(double axial, double lateral, double yaw) {
         this.axial = axial;
         this.lateral = lateral;
         this.yaw = yaw;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/LinearMovementTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/LinearMovementTask.java
@@ -1,0 +1,27 @@
+package org.firstinspires.ftc.teamcode.task;
+
+/**
+ * Tells a robot supporting holonomic drive to move in a straight line without turning.
+ */
+public class LinearMovementTask implements Task {
+    /**
+     * The distance in meters to move in the forward direction.
+     * Negative values indicate backward movement.
+     */
+    public double axial;
+    /**
+     * The distance in meters to move to the robot's rightward direction.
+     * Negative values indicate leftward movement.
+     */
+    public double lateral;
+
+    /**
+     * Constructs a LinearMovementTask.
+     * @param axial - the distance to move in the forward direction
+     * @param lateral - the distance to move in the rightward direction
+     */
+    public LinearMovementTask(double axial, double lateral) {
+        this.axial = axial;
+        this.lateral = lateral;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/MecanumDriveTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/MecanumDriveTask.java
@@ -1,0 +1,3 @@
+package org.firstinspires.ftc.teamcode.task;
+
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/MecanumDriveTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/MecanumDriveTask.java
@@ -1,3 +1,35 @@
 package org.firstinspires.ftc.teamcode.task;
 
-
+/**
+ * Specifies relative accelerations for the axial, lateral, and yaw component of a mecanum drive.
+ */
+public class MecanumDriveTask implements Task {
+    /**
+     * The relative acceleration to apply in the direction the robot is facing.
+     * Positive values indicate forward movement and negative values indicate backward.
+     */
+    public double axial;
+    /**
+     * The relative acceleration to apply in the perpendicular direction to the one the robot is
+     * facing.
+     * Positive values indicate rightward movement and negative values indicate leftward.
+     */
+    public double lateral;
+    /**
+     * The relative acceleration to use to turn the robot.
+     * Positive values indicate counterclockwise turning and negative values indicate clockwise.
+     */
+    public double yaw;
+    /**
+     * Constructs a MecanumDriveTask.
+     * @param axial - the relative acceleration to apply in the direction the robot is facing.
+     * @param lateral - the relative acceleration to apply in the direction perpendicular to the one
+     * the robot is facing.
+     * @param yaw - the relative acceleration to use to turn the robot.
+     */
+    public MecanumDriveTask(double axial, double lateral, double yaw) {
+        this.axial = axial;
+        this.lateral = lateral;
+        this.yaw = yaw;
+    }
+}


### PR DESCRIPTION
- **Fix motor jitter bug in TwoWheelDrive**
  Apply bugfix from PiE code that didn't make it into FTC yet where motor powers would be set to
  zero after a tiny delay for teleop tasks.
- **Add MecanumDrive with two wheel drive tasks**
  Pretty much copy TwoWheelDrive but add WheelProperty to organize all the props where each wheel
  would have a different value. Still supports the same tasks TwoWheelDrive does because
  mecanum-specific tasks don't exist yet.
- **Lint**
- **Add some mecanum tasks**
- **Finish MecanumDriveTask**
  Add holonomic teleop and auto tasks.
- **Support mecanum-specific tasks in MecanumDrive**
  ...and support them in MecanumDrive.
- **Lint**
- **Add input mapping for holonomic drive**
  Add a holonomic drive input mapping that uses left joystick to move and right x to turn.
