### PR TITLE
Add LiftLayer and support multiplexing layers

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/CircularBuffer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/CircularBuffer.java
@@ -32,7 +32,7 @@ public class CircularBuffer<E> implements Collection<E> {
 
     @Override
     public boolean addAll(Collection<? extends E> c) {
-        c.forEach(add);
+        c.forEach(this::add);
         return true;
     }
 
@@ -50,6 +50,11 @@ public class CircularBuffer<E> implements Collection<E> {
     @Override
     public boolean containsAll(Collection<?> c) {
         return buffer.containsAll(c);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return buffer.isEmpty();
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/CircularBuffer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/CircularBuffer.java
@@ -1,0 +1,101 @@
+package org.firstinspires.ftc.teamcode;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * A collection of fixed maximum size to which elements may always be added.
+ * If the maximum size is reached, adding an element overwrites the oldest in the collection.
+ */
+public class CircularBuffer<E> implements Collection<E> {
+    private final int maxSize;
+    private final ArrayList<E> buffer;
+    private int idx;
+
+    public CircularBuffer(int maxSize) {
+        this.maxSize = maxSize;
+        buffer = new ArrayList<>(maxSize);
+        idx = 0;
+    }
+
+    @Override
+    public boolean add(E e) {
+        if (buffer.size() < maxSize) {
+            buffer.add(e);
+        } else {
+            buffer.set(idx, e);
+            idx = (idx + 1) % maxSize;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        c.forEach(add);
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        buffer.clear();
+        idx = 0;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return buffer.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return buffer.containsAll(c);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        // Mask Iterator.remove
+        Iterator<E> iter = buffer.iterator();
+        return new Iterator<E>() {
+            @Override
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
+
+            @Override
+            public E next() {
+                return iter.next();
+            }
+        };
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int size() {
+        return buffer.size();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return buffer.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return buffer.toArray(a);
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
@@ -157,6 +157,7 @@ public class RobotController {
                 return true;
             }
         }
+        layerIter.previous(); // Throw away current layer
         Iterator<Task> tasks;
         while (true) {
             if (!layerIter.hasPrevious()) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/FunctionLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/FunctionLayer.java
@@ -28,8 +28,8 @@ public abstract class FunctionLayer implements Layer {
 
     @Override
     public void acceptTask(Task task) {
-        emittedSubtask = false;
         subtask = map(task);
+        emittedSubtask = false;
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/FunctionLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/FunctionLayer.java
@@ -1,5 +1,8 @@
 package org.firstinspires.ftc.teamcode.layer;
 
+import java.util.Collections;
+import java.util.Iterator;
+
 import org.firstinspires.ftc.teamcode.task.Task;
 
 /**
@@ -21,9 +24,9 @@ public abstract class FunctionLayer implements Layer {
     }
 
     @Override
-    public Task update() {
+    public Iterator<Task> update(Iterable<Task> completed) {
         emittedSubtask = true;
-        return subtask;
+        return Collections.singleton(subtask).iterator();
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/Layer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/Layer.java
@@ -13,7 +13,7 @@ import org.firstinspires.ftc.teamcode.task.Task;
 public interface Layer {
     /**
      * Performs layer setup that requires access to hardware and the RobotController.
-     * @param setup LayerSetupInfo provided to set up the layer.
+     * @param setup - LayerSetupInfo provided to set up the layer.
      */
     void setup(LayerSetupInfo setup);
 
@@ -36,9 +36,12 @@ public interface Layer {
 
     /**
      * Sets the layer's current task.
-     * Accepts a task from the above layer. Should only be called after {@link Layer#isTaskDone}
-     * returns True.
-     * @param task the task this layer should start processing.
+     * Accepts a task from the above layer.
+     * Behavior is only defined if {@link Layer#isTaskDone} returns true.
+     * @param task - the task this layer should start processing.
+     * @throws UnsupportedTaskException - this layer does not support the given task.
+     * Implementations must not change the internal state of the layer if this is thrown; isTaskDone
+     * should still return true.
      */
     void acceptTask(Task task);
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/Layer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/Layer.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode.layer;
 
 import org.firstinspires.ftc.teamcode.task.Task;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
 
 /**
  * A modular unit of robot functionality.
@@ -9,6 +10,9 @@ import org.firstinspires.ftc.teamcode.task.Task;
  * and concrete ones. (A task is an instruction passed from a layer to its subordinate. Tasks range
  * widely in their concreteness and can be as vague as "win the game" or as specific as "move
  * forward 2 meters.")
+ *
+ * See {@link org.firstinspires.ftc.teamcode.RobotController} for detailed information about layer
+ * processing.
  */
 public interface Layer {
     /**
@@ -19,20 +23,21 @@ public interface Layer {
 
     /**
      * Returns whether the layer is ready to accept a new task.
-     * This method shouldbe free of any side effects; move code mutating state to update or
+     * This method should be free of any side effects; move code mutating state to update or
      * acceptTask.
      * @return true if the layer has finished processing the last accepted task, if any.
      */
     boolean isTaskDone();
 
     /**
-     * Returns the next subordinate task produced from this layer's current task.
-     * Calculates the next subordinate task that should be submitted to the below layer. The return
-     * value of a bottom layer's update function is not used.
+     * Returns the next subordinate tasks produced from this layer's current task.
+     * Calculates the next subordinate tasks that should be submitted to the below layer. If the
+     * returned iterator contains more than one task, all are offered to the below layer
+     * @param completed - an iterable of tasks completed since the last call to update.
      * @return The next task that the lower layer should run. Must not be null unless this is the
      * bottommost layer.
      */
-    Task update();
+    Iterator<Task> update(Iterator<Task> completed);
 
     /**
      * Sets the layer's current task.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/Layer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/Layer.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.layer;
 
+import java.util.Iterator;
+
 import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
 
@@ -32,12 +34,12 @@ public interface Layer {
     /**
      * Returns the next subordinate tasks produced from this layer's current task.
      * Calculates the next subordinate tasks that should be submitted to the below layer. If the
-     * returned iterator contains more than one task, all are offered to the below layer
+     * returned iterator contains more than one task, all are offered to the lower layer.
      * @param completed - an iterable of tasks completed since the last call to update.
      * @return The next task that the lower layer should run. Must not be null unless this is the
      * bottommost layer.
      */
-    Iterator<Task> update(Iterator<Task> completed);
+    Iterator<Task> update(Iterable<Task> completed);
 
     /**
      * Sets the layer's current task.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/LayerSetupInfo.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/LayerSetupInfo.java
@@ -58,7 +58,8 @@ public class LayerSetupInfo {
     }
     /**
      * Registers a callback to be called on every update of the owning RobotController.
-     * @param listener The callback to be called.
+     * @param listener - the callback to be called. Passed with a value of true during teardown, and
+     * false otherwise.
      */
     public void addUpdateListener(Consumer<Boolean> listener) {
         robotController.addUpdateListener(listener);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
@@ -20,7 +20,7 @@ public class MultiplexLayer implements Layer {
     }
 
     @Override
-    public Task update() {
+    public Iterable<Task> update(Iterable<Task> completed) {
         // ??? How do we know which layer to ask for a new subtask from
         return null;
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
@@ -1,0 +1,47 @@
+package org.firstinspires.ftc.teamcode.layer;
+
+import java.util.List;
+
+import org.firstinspires.ftc.teamcode.task.Task;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
+
+public class MultiplexLayer implements Layer {
+    private final List<Layer> layers;
+
+    public MultiplexLayer(List<Layer> layers) {
+        this.layers = layers;
+    }
+
+    @Override
+    public void setup(LayerSetupInfo setupInfo) {
+        for (Layer layer : layers) {
+            layer.setup(setupInfo);
+        }
+    }
+
+    @Override
+    public Task update() {
+        // ??? How do we know which layer to ask for a new subtask from
+    }
+
+    @Override
+    public boolean isTaskDone() {
+        return layers.stream().anyMatch(Layer::isTaskDone);
+    }
+
+    @Override
+    public void acceptTask(Task task) {
+        boolean anyAccepted = layers.stream().anyMatch((layer) -> {
+            try {
+                layer.acceptTask(task);
+            } catch (UnsupportedTaskException e) {
+                return false;
+            }
+            return true;
+        });
+        if (!anyAccepted) {
+            // Should list component layers, not say MultiplexLayer
+            throw new UnsupportedTaskException(this, layer);
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
@@ -1,6 +1,9 @@
 package org.firstinspires.ftc.teamcode.layer;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
 
 import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
@@ -20,9 +23,18 @@ public class MultiplexLayer implements Layer {
     }
 
     @Override
-    public Iterable<Task> update(Iterable<Task> completed) {
-        // ??? How do we know which layer to ask for a new subtask from
-        return null;
+    public Iterator<Task> update(Iterable<Task> completed) {
+        // Concatenates results of component layer update methods into a single stream, then creates
+        // an iterator from the stream
+        return layers.stream().flatMap(layer ->
+            StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(
+                    layer.update(completed),
+                    0
+                ),
+                false
+            )
+        ).iterator();
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/MultiplexLayer.java
@@ -22,6 +22,7 @@ public class MultiplexLayer implements Layer {
     @Override
     public Task update() {
         // ??? How do we know which layer to ask for a new subtask from
+        return null;
     }
 
     @Override
@@ -41,7 +42,7 @@ public class MultiplexLayer implements Layer {
         });
         if (!anyAccepted) {
             // Should list component layers, not say MultiplexLayer
-            throw new UnsupportedTaskException(this, layer);
+            throw new UnsupportedTaskException(this, task);
         }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
@@ -125,18 +125,14 @@ public class TwoWheelDrive implements Layer {
 
     @Override
     public void acceptTask(Task task) {
-        currentTaskDone = false;
-        leftStartPos = leftWheel.getDistance();
-        rightStartPos = rightWheel.getDistance();
-        double deltaFac = GEAR_RATIO * SLIPPING_CONSTANT;
         if (task instanceof AxialMovementTask) {
             AxialMovementTask castedTask = (AxialMovementTask)task;
-            leftGoalDelta = castedTask.distance * deltaFac;
-            rightGoalDelta = castedTask.distance * deltaFac;
+            leftGoalDelta = castedTask.distance * GEAR_RATIO * SLIPPING_CONSTANT;
+            rightGoalDelta = castedTask.distance * GEAR_RATIO * SLIPPING_CONSTANT;
         } else if (task instanceof TurnTask) {
             TurnTask castedTask = (TurnTask)task;
-            leftGoalDelta = -castedTask.angle * WHEEL_SPAN_RADIUS * deltaFac;
-            rightGoalDelta = castedTask.angle * WHEEL_SPAN_RADIUS * deltaFac;
+            leftGoalDelta = -castedTask.angle * WHEEL_SPAN_RADIUS * GEAR_RATIO * SLIPPING_CONSTANT;
+            rightGoalDelta = castedTask.angle * WHEEL_SPAN_RADIUS * GEAR_RATIO * SLIPPING_CONSTANT;
         } else if (task instanceof TankDriveTask) {
             // Teleop, set deltas to 0 to pretend we're done
             leftGoalDelta = 0;
@@ -151,6 +147,9 @@ public class TwoWheelDrive implements Layer {
         } else {
             throw new UnsupportedTaskException(this, task);
         }
+        currentTaskDone = false;
+        leftStartPos = leftWheel.getDistance();
+        rightStartPos = rightWheel.getDistance();
         leftWheel.setVelocity(Math.signum(leftGoalDelta));
         rightWheel.setVelocity(Math.signum(rightGoalDelta));
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/drive/TwoWheelDrive.java
@@ -2,6 +2,8 @@ package org.firstinspires.ftc.teamcode.layer.drive;
 
 import com.qualcomm.robotcore.hardware.DcMotor;
 
+import java.util.Iterator;
+
 import org.firstinspires.ftc.teamcode.layer.Layer;
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.mechanism.Wheel;
@@ -102,7 +104,7 @@ public class TwoWheelDrive implements Layer {
     }
 
     @Override
-    public Task update() {
+    public Iterator<Task> update(Iterable<Task> completed) {
         double leftDelta = leftWheel.getDistance() - leftStartPos;
         boolean leftDeltaSignsMatch = (leftDelta < 0) == (leftGoalDelta < 0);
         boolean leftGoalDeltaExceeded = Math.abs(leftDelta) >= Math.abs(leftGoalDelta);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
@@ -3,8 +3,6 @@ package org.firstinspires.ftc.teamcode.layer.input;
 import com.qualcomm.robotcore.hardware.Gamepad;
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.task.GamepadInputTask;
-import org.firstinspires.ftc.teamcode.task.Task;
-import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
 
 public class GamepadInputGenerator extends InputGenerator {
     private Gamepad gamepad0;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
@@ -1,6 +1,10 @@
 package org.firstinspires.ftc.teamcode.layer.input;
 
 import com.qualcomm.robotcore.hardware.Gamepad;
+
+import java.util.Collections;
+import java.util.Iterator;
+
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.task.GamepadInputTask;
 import org.firstinspires.ftc.teamcode.task.Task;
@@ -18,8 +22,8 @@ public class GamepadInputGenerator extends InputGenerator {
         }
     }
 
-    public Task update() {
-        return new GamepadInputTask(
+    public Iterator<Task> update(Iterable<Task> completed) {
+        return Collections.singleton((Task)(new GamepadInputTask(
             gamepad0 == null ? null : new GamepadInputTask.GamepadInput(
                 gamepad0.left_stick_x,
                 gamepad0.left_stick_y,
@@ -56,6 +60,6 @@ public class GamepadInputGenerator extends InputGenerator {
                 gamepad1.x,
                 gamepad1.y
             )
-        );
+        ))).iterator();
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/GamepadInputGenerator.java
@@ -3,6 +3,7 @@ package org.firstinspires.ftc.teamcode.layer.input;
 import com.qualcomm.robotcore.hardware.Gamepad;
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.task.GamepadInputTask;
+import org.firstinspires.ftc.teamcode.task.Task;
 
 public class GamepadInputGenerator extends InputGenerator {
     private Gamepad gamepad0;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/InputGenerator.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/InputGenerator.java
@@ -12,10 +12,12 @@ import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
  * in the likely case that the input generator is the top layer.
  */
 public abstract class InputGenerator implements Layer {
+    @Override
     public boolean isTaskDone() {
         return false;
     }
 
+    @Override
     public void acceptTask(Task task) {
         throw new UnsupportedTaskException(this, task);
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/RightLiftMapping.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/RightLiftMapping.java
@@ -1,0 +1,32 @@
+package org.firstinspires.ftc.teamcode.layer.input.mapping;
+
+import org.firstinspires.ftc.teamcode.layer.FunctionLayer;
+import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
+import org.firstinspires.ftc.teamcode.task.GamepadInputTask;
+import org.firstinspires.ftc.teamcode.task.Task;
+import org.firstinspires.ftc.teamcode.task.LiftTask;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
+
+/**
+ * Mapping for gamepad input that uses the right bumper and trigger to control a lift.
+ */
+public class RightLiftMapping extends FunctionLayer {
+    @Override
+    public void setup(LayerSetupInfo setupInfo) { }
+
+    @Override
+    public Task map(Task task) {
+        if (task instanceof GamepadInputTask) {
+            GamepadInputTask castedTask = (GamepadInputTask)task;
+            boolean raise = castedTask.gamepad0.bumpers.right;
+            boolean lower = castedTask.gamepad0.triggers.right;
+            boolean valid = !(raise && lower);
+            return new LiftTask(
+                valid && raise,
+                valid && lower
+            );
+        } else {
+            throw new UnsupportedTaskException(this, task);
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
@@ -1,0 +1,77 @@
+package org.firstinspires.ftc.teamcode.layer.manipulator;
+
+import org.firstinspires.ftc.teamcode.layer.Layer;
+
+public class LiftLayer implements Layer {
+    /**
+     * Height above zeroDist in meters of the lift when fully extended.
+     */
+    private static final RAISE_HEIGHT = 0.42;
+    /**
+     * Height just above zeroDist to meters of the lift to move to when lowering.
+     * After lowering to this distance, the motor is disengaged and gravity lowers the lift the rest
+     * of the way.
+     */
+    private static final LOWER_HEIGHT = 0.1;
+
+    private Wheel pulley;
+    private double zeroDist;
+    private double goalDist;
+    private boolean engaged;
+    private boolean goalAchieved;
+
+    @Override
+    public void setup(LayerSetupInfo setupInfo) {
+        pulley = new Wheel(
+            setupInfo.getHardwareMap().get(DcMotor.class, "lift_motor"),
+            PULLEY_RADIUS
+        );
+        TouchSensor zeroSwitch = setupInfo.getHardwareMap().get(TouchSensor.class,
+            "lift_zero_switch");
+        zeroDist = pulley.getDistance();
+        startDist = zeroDist;
+        goalDist = zeroDist;
+        engaged = false;
+        goalAchieved = true;
+        setupInfo.addUpdateListener((isTeardown) -> {
+            if (zeroSwitch.isPressed()) {
+                zeroDist = pulley.getDistance();
+            }
+        });
+    }
+
+    @Override
+    public boolean isTaskDone() {
+        return goalAchieved;
+    }
+
+    @Override
+    public Task update() {
+        double remainingDelta = goalDist - getPulleyPos();
+        double startDelta = goalDist - startDist;
+        if ((remainingDelta < 0) != (startDelta < 0)) {
+            goalAchieved = true;
+        }
+        double velocity = 0; // use pid or something
+        return null;
+    }
+
+    @Override
+    public void acceptTask(Task task) {
+        if (task instanceof LiftTask) {
+            LiftTask castedTask = (LiftTask)task;
+            goalAchieved = false;
+            if (castedTask.raise) {
+                goalDist = RAISE_HEIGHT;
+            } else if (castedTask.lower) {
+                goalDist = LOWER_HEIGHT;
+            }
+        } else {
+            throw new UnsupportedTaskException(this, task);
+        }
+    }
+
+    private final getPulleyDistance() {
+        return pulley.getDistance() - zeroDist;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
@@ -10,6 +10,7 @@ import org.firstinspires.ftc.teamcode.mechanism.Wheel;
 import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.LiftTask;
 import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
+import org.firstinspires.ftc.teamcode.Units;
 
 /**
  * Controls an extendable lift operated by a pulley.
@@ -18,13 +19,17 @@ public class LiftLayer implements Layer {
     /**
      * Height above zeroDist in meters of the lift when fully extended.
      */
-    private static final double RAISE_HEIGHT = 0.42;
+    private static final double RAISE_HEIGHT = Units.convert(46.375 - 16.875, Units.Distance.IN, Units.Distance.M);
     /**
      * Height just above zeroDist to meters of the lift to move to when lowering.
      * After lowering to this distance, the motor is disengaged and gravity lowers the lift the rest
      * of the way.
      */
-    private static final double LOWER_HEIGHT = 0.1;
+    private static final double LOWER_HEIGHT = Units.convert(10, Units.Distance.CM, Units.Distance.M);
+    /**
+     * Displacing the string translates the lift by the amount string displaced times this number.
+     */
+    private static final double STRING_FAC = 2;
     /**
      * Maximum number of pulley goal deltas to track for integral calculation.
      * Increasing this reduces the calculation's sensitivity to recent rapid changes in goal error.
@@ -99,7 +104,7 @@ public class LiftLayer implements Layer {
     public Task update() {
         pulleyMotor.setZeroPowerBehavior(raising ? DcMotor.ZeroPowerBehavior.BRAKE
             : DcMotor.ZeroPowerBehavior.FLOAT);
-        double goalDist = raising ? RAISE_HEIGHT : LOWER_HEIGHT;
+        double goalDist = (raising ? RAISE_HEIGHT : LOWER_HEIGHT) / STRING_FAC;
         double remainingDelta = goalDist - getPulleyDistance();
         double startDelta = goalDist - startDist;
         if ((remainingDelta < 0) != (startDelta < 0)) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
@@ -1,8 +1,15 @@
 package org.firstinspires.ftc.teamcode.layer.manipulator;
 
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.TouchSensor;
+
 import org.firstinspires.ftc.teamcode.CircularBuffer;
 import org.firstinspires.ftc.teamcode.layer.Layer;
+import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
+import org.firstinspires.ftc.teamcode.mechanism.Wheel;
+import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.LiftTask;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
 
 /**
  * Controls an extendable lift operated by a pulley.
@@ -31,6 +38,10 @@ public class LiftLayer implements Layer {
      * Weight of integral component in pulley velocity calculation.
      */
     private static final double PULLEY_I_COEFF = 0.05;
+    /**
+     * Radius of the pulley in meters.
+     */
+    private static final double PULLEY_RADIUS = 0.42;
 
     /**
      * The motor used to power the lift, only retained to change zero power behavior.
@@ -64,10 +75,7 @@ public class LiftLayer implements Layer {
     @Override
     public void setup(LayerSetupInfo setupInfo) {
         pulleyMotor = setupInfo.getHardwareMap().get(DcMotor.class, "lift_motor");
-        pulley = new Wheel(
-            liftMotor,
-            PULLEY_RADIUS
-        );
+        pulley = new Wheel(pulleyMotor, PULLEY_RADIUS);
         TouchSensor zeroSwitch = setupInfo.getHardwareMap().get(TouchSensor.class,
             "lift_zero_switch");
         zeroDist = pulley.getDistance();
@@ -99,6 +107,8 @@ public class LiftLayer implements Layer {
         }
         if (!raising && goalAchieved) {
             pulley.setVelocity(0);
+        } else if (!raising) {
+            pulley.setVelocity(-1);
         } else {
             double proportional = PULLEY_P_COEFF * remainingDelta;
             double integral = PULLEY_I_COEFF * deltaHistory
@@ -109,7 +119,7 @@ public class LiftLayer implements Layer {
             deltaHistory.add(remainingDelta);
             double velocity = Math.max(-1.0, Math.min(1.0, proportional + integral));
             pulley.setVelocity(velocity);
-        } 
+        }
         return null;
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
@@ -1,40 +1,82 @@
 package org.firstinspires.ftc.teamcode.layer.manipulator;
 
+import org.firstinspires.ftc.teamcode.CircularBuffer;
 import org.firstinspires.ftc.teamcode.layer.Layer;
+import org.firstinspires.ftc.teamcode.task.LiftTask;
 
+/**
+ * Controls an extendable lift operated by a pulley.
+ */
 public class LiftLayer implements Layer {
     /**
      * Height above zeroDist in meters of the lift when fully extended.
      */
-    private static final RAISE_HEIGHT = 0.42;
+    private static final double RAISE_HEIGHT = 0.42;
     /**
      * Height just above zeroDist to meters of the lift to move to when lowering.
      * After lowering to this distance, the motor is disengaged and gravity lowers the lift the rest
      * of the way.
      */
-    private static final LOWER_HEIGHT = 0.1;
+    private static final double LOWER_HEIGHT = 0.1;
+    /**
+     * Maximum number of pulley goal deltas to track for integral calculation.
+     * Increasing this reduces the calculation's sensitivity to recent rapid changes in goal error.
+     */
+    private static final int DELTA_HISTORY_COUNT = 2000;
+    /**
+     * Weight of proportional component in pulley velocity calculation.
+     */
+    private static final double PULLEY_P_COEFF = 0.05;
+    /**
+     * Weight of integral component in pulley velocity calculation.
+     */
+    private static final double PULLEY_I_COEFF = 0.05;
 
+    /**
+     * The motor used to power the lift, only retained to change zero power behavior.
+     */
+    private DcMotor pulleyMotor;
+    /**
+     * The pulley powering the lift.
+     */
     private Wheel pulley;
+    /**
+     * The "distance" reported by the pulley when the lift is at its minimum height.
+     */
     private double zeroDist;
-    private double goalDist;
-    private boolean engaged;
+    /**
+     * The pulley distance measured at the beginning of the current task.
+     */
+    private double startDist;
+    /**
+     * Whether the lift was last set to raise.
+     */
+    private boolean raising;
+    /**
+     * Whether the goal set for the current task has been achieved.
+     */
     private boolean goalAchieved;
+    /**
+     * The recent history of goal deltas.
+     */
+    private CircularBuffer<Double> deltaHistory;
 
     @Override
     public void setup(LayerSetupInfo setupInfo) {
+        pulleyMotor = setupInfo.getHardwareMap().get(DcMotor.class, "lift_motor");
         pulley = new Wheel(
-            setupInfo.getHardwareMap().get(DcMotor.class, "lift_motor"),
+            liftMotor,
             PULLEY_RADIUS
         );
         TouchSensor zeroSwitch = setupInfo.getHardwareMap().get(TouchSensor.class,
             "lift_zero_switch");
         zeroDist = pulley.getDistance();
         startDist = zeroDist;
-        goalDist = zeroDist;
-        engaged = false;
+        raising = false;
         goalAchieved = true;
+        deltaHistory = new CircularBuffer<>(DELTA_HISTORY_COUNT);
         setupInfo.addUpdateListener((isTeardown) -> {
-            if (zeroSwitch.isPressed()) {
+            if (zeroSwitch.isPressed() && !isTeardown) {
                 zeroDist = pulley.getDistance();
             }
         });
@@ -47,12 +89,27 @@ public class LiftLayer implements Layer {
 
     @Override
     public Task update() {
-        double remainingDelta = goalDist - getPulleyPos();
+        pulleyMotor.setZeroPowerBehavior(raising ? DcMotor.ZeroPowerBehavior.BRAKE
+            : DcMotor.ZeroPowerBehavior.FLOAT);
+        double goalDist = raising ? RAISE_HEIGHT : LOWER_HEIGHT;
+        double remainingDelta = goalDist - getPulleyDistance();
         double startDelta = goalDist - startDist;
         if ((remainingDelta < 0) != (startDelta < 0)) {
             goalAchieved = true;
         }
-        double velocity = 0; // use pid or something
+        if (!raising && goalAchieved) {
+            pulley.setVelocity(0);
+        } else {
+            double proportional = PULLEY_P_COEFF * remainingDelta;
+            double integral = PULLEY_I_COEFF * deltaHistory
+                .stream()
+                .mapToDouble(Double::doubleValue)
+                .average()
+                .orElse(0);
+            deltaHistory.add(remainingDelta);
+            double velocity = Math.max(-1.0, Math.min(1.0, proportional + integral));
+            pulley.setVelocity(velocity);
+        } 
         return null;
     }
 
@@ -61,17 +118,22 @@ public class LiftLayer implements Layer {
         if (task instanceof LiftTask) {
             LiftTask castedTask = (LiftTask)task;
             goalAchieved = false;
+            startDist = getPulleyDistance();
+            deltaHistory.clear();
             if (castedTask.raise) {
-                goalDist = RAISE_HEIGHT;
+                raising = true;
             } else if (castedTask.lower) {
-                goalDist = LOWER_HEIGHT;
+                raising = false;
             }
         } else {
             throw new UnsupportedTaskException(this, task);
         }
     }
 
-    private final getPulleyDistance() {
+    /**
+     * Calculates the current distance from the base to the top of the lift.
+     */
+    private double getPulleyDistance() {
         return pulley.getDistance() - zeroDist;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
@@ -3,6 +3,8 @@ package org.firstinspires.ftc.teamcode.layer.manipulator;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.TouchSensor;
 
+import java.util.Iterator;
+
 import org.firstinspires.ftc.teamcode.CircularBuffer;
 import org.firstinspires.ftc.teamcode.layer.Layer;
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
@@ -103,7 +105,7 @@ public class LiftLayer implements Layer {
     }
 
     @Override
-    public Task update() {
+    public Iterator<Task> update(Iterable<Task> completed) {
         pulleyMotor.setZeroPowerBehavior(raising ? DcMotor.ZeroPowerBehavior.BRAKE
             : DcMotor.ZeroPowerBehavior.FLOAT);
         double goalDist = (raising ? RAISE_HEIGHT : LOWER_HEIGHT) / STRING_FAC;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
@@ -27,7 +27,9 @@ public class LiftLayer implements Layer {
      */
     private static final double LOWER_HEIGHT = Units.convert(10, Units.Distance.CM, Units.Distance.M);
     /**
-     * Displacing the string translates the lift by the amount string displaced times this number.
+     * The factor by which the pulleys magnify the translation of the string by the motor.
+     * In other words, if the motor displaces the string by x distance the lift will be displaced by
+     * x * STRING_FAC.
      */
     private static final double STRING_FAC = 2;
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/LiftTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/LiftTask.java
@@ -1,0 +1,28 @@
+package org.firstinspires.ftc.teamcode.task;
+
+/**
+ * Raises or lowers the lift.
+ */
+public class LiftTask implements Task {
+    /**
+     * Whether the lift should be raised.
+     */
+    public boolean raise;
+    /**
+     * Whether the lift should be lowered.
+     */
+    public boolean lower;
+
+    /**
+     * Constructs a LiftTask.
+     * @param raise - whether the lift should be raised.
+     * @param lower - whether the lift should be lowered.
+     */
+    public LiftTask(boolean raise, boolean lower) {
+        this.raise = raise;
+        this.lower = lower;
+        if (raise && lower) {
+            throw new InvalidArgumentException("Cannot simultaneously raise and lower the lift.");
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/LiftTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/LiftTask.java
@@ -22,7 +22,7 @@ public class LiftTask implements Task {
         this.raise = raise;
         this.lower = lower;
         if (raise && lower) {
-            throw new InvalidArgumentException("Cannot simultaneously raise and lower the lift.");
+            throw new IllegalArgumentException("Cannot simultaneously raise and lower the lift.");
         }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/UnsupportedTaskException.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/UnsupportedTaskException.java
@@ -7,13 +7,20 @@ import org.firstinspires.ftc.teamcode.layer.Layer;
  */
 public class UnsupportedTaskException extends IllegalArgumentException {
     /**
-     * Constructs an UnsupportedTaskException.
-     *
-     * @param layer the Layer throwing the exception.
-     * @param task the Task that the layer rejected.
+     * Constructs an UnsupportedTaskException for a layer that does not support a task with a
+     * standard error message.
+     * @param layer - the Layer throwing the exception.
+     * @param task - the Task that the layer rejected.
      */
     public UnsupportedTaskException(Layer layer, Task task) {
         super("Layer '" + layer.getClass().getName() + "' does not support task of type '"
             + task.getClass().getName() + "'.");
+    }
+    /**
+     * Constructs an UnsupportedTaskException with a custom error message.
+     * @param msg - the exception message.
+     */
+    public UnsupportedTaskException(String msg) {
+        super(msg);
     }
 }


### PR DESCRIPTION
- **Change Layer.acceptTask contract**
  Require that acceptTask not change internal state if passed an unsupported task.
- **Start MultiplexLayer which might be abandoned**
  Start MultiplexLayer, though for the time being I can't figure out what the layer above it is
  supposed to do when asked to update. Which kind of task does it return? Can it waste tasks
  without assuming they'll be completed?
- **Add LiftTask**
- **Add input mapping to control lift**
- **Lint**
- **Start LiftLayer**
- **Add CircularBuffer collection**
  Useful utility class, for now just used to keep track of PID error history for LiftLayer.
- **Finish LiftLayer**
- **Lint**
- **Fill in constants for LiftLayer**
- **Improve LiftLayer.STRING_FAC documentation**
- **Change Layer.update signature**
  Revamp to support MultiplexLayer, answering the previous question by passing an iterable of
  completed tasks to update.
- **Change RobotController to use new Layer interface**
- **Finally implement MultiplexLayer.update**
- **Change all Layers to use new update signature**
