### PR TITLE
Add Gradle javadoc task

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -14,27 +14,40 @@ plugins {
   id 'checkstyle'
 }
 
-tasks.register('javadoc', Javadoc) {
-  source = 'src/main/java'
-  classpath = configurations.releaseCompileClasspath
-  Configuration baseConf = configurations.releaseCompileClasspath
-  //classpath = configurations.create('resolvableReleaseCompileClasspath')
-  baseConf.allDependencies.forEach {
-    if (it instanceof ProjectDependency) {
-      evaluationDependsOn(it.dependencyProject.path)
-    } else {
-      classpath.dependencies.add(it)
+tasks.register('createResolvableReleaseCompileClasspath') {
+  configurations.create('resolvableReleaseCompileClasspath') {
+    configurations.releaseCompileClasspath.allDependencies.forEach {
+      if (it instanceof ProjectDependency) {
+        evaluationDependsOn(it.dependencyProject.path)
+      } else {
+        dependencies.add(it)
+      }
     }
   }
-  //classpath.attributes {
-    //attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'jar')
-    //attribute(BuildTypeAttr.ATTRIBUTE, 'release')
-  //}
-  classpath.resolutionStrategy {
-
+}
+FileCollection javadocClasspath = files()
+tasks.register('createJavadocClasspath') {
+  dependsOn(tasks.createResolvableReleaseCompileClasspath)
+    configurations.resolvableReleaseCompileClasspath.forEach {
+    String path = it.getPath()
+    if (path.endsWith('aar')) {
+      javadocClasspath = (javadocClasspath
+        + zipTree(path).matching(new PatternSet().include('classes.jar')))
+    } else if (path.endsWith('jar')) {
+      javadocClasspath = javadocClasspath + files(it)
+    } else {
+      throw new RuntimeException("Can't handle artifact type: '" + path + "'")
+    }
   }
+}
+tasks.register('javadoc', Javadoc) {
+  dependsOn(tasks.createJavadocClasspath)
+  source = 'src/main/java'
+  classpath = javadocClasspath
+  title = '22047 TeamCode'
   destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
   options {
+    header = 'FTC 22047 "Tell-Tale Parts"'
     memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
   }
 }

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -53,8 +53,16 @@ tasks.register('createJavadocClasspath') {
     }
   }
 }
+tasks.register('getJavadocPackageLists') {
+  description = ("Fetches package-list files of dependencies' javadocs so they can be linked to"
+    + " from ours.")
+  doLast {
+
+  }
+}
 tasks.register('javadoc', Javadoc) {
   dependsOn('createJavadocClasspath')
+  dependsOn('getJavadocPackageLists')
   description = 'Creates javadocs for the TeamCode subproject'
   group = 'build'
   source = 'src/main/java'
@@ -63,9 +71,11 @@ tasks.register('javadoc', Javadoc) {
     // createJavadocClasspath runs to set it
     classpath = project.ext.javadocClasspath
   }
+  // Controls the name of the index file
   title = 'TeamCode'
   destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
   options {
+    // Small text in the top-right corner of the screen
     header = 'FTC 22047 "Tell-Tale Parts"'
     // Document everything because we're not writing an API; these docs are for our own benefit.
     memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
@@ -80,7 +90,7 @@ tasks.register('javadoc', Javadoc) {
     //addBooleanOption('linksource', true)
     // Lints javadoc comments. Might be enabled by default.
     addBooleanOption('Xdoclint', true)
-    // Adds links to the javadocs for RobotCore classes
+    // Adds links to the javadocs for RobotCore classes. TODO: use linkoffline instead
     addStringOption('link', 'https://javadoc.io/doc/org.firstinspires.ftc/RobotCore/10.1.1/')
   }
   doLast {

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -14,35 +14,17 @@ plugins {
   id 'checkstyle'
 }
 
-ext.sourceSets = container(SourceSet) {
-  main {
-    java {
-      srcDir 'src/main/java'
-    }
-    resources {
-      srcDir 'src/main/res'
-    }
-  }
-}
-
-tasks.register('tmpdebug') {
-  println project.ext
-  println ext
-  project.ext.getProperties().entrySet().forEach {
-    println(it.getKey() + ":" + it.getValue())
-  }
-  println project.sourceSets
-  project.sourceSets.forEach {
-    println $it
-  }
-}
-
 tasks.register('javadoc', Javadoc) {
-  source = sourceSets.main.getAllJava()
+  source = 'src/main/java'
   destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
   options {
     memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
   }
+  project.configurations.getByName("android-classes-directory").canBeResolved = true
+  project.configurations.getByName("android-classes-directory").forEach {
+    println it
+  }
+  failOnError = false
 }
 
 // Include common definitions from above.

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -10,10 +10,45 @@
 
 
 // Custom definitions may go here
+plugins {
+  id 'checkstyle'
+}
+
+ext.sourceSets = container(SourceSet) {
+  main {
+    java {
+      srcDir 'src/main/java'
+    }
+    resources {
+      srcDir 'src/main/res'
+    }
+  }
+}
+
+tasks.register('tmpdebug') {
+  println project.ext
+  println ext
+  project.ext.getProperties().entrySet().forEach {
+    println(it.getKey() + ":" + it.getValue())
+  }
+  println project.sourceSets
+  project.sourceSets.forEach {
+    println $it
+  }
+}
+
+tasks.register('javadoc', Javadoc) {
+  source = sourceSets.main.getAllJava()
+  destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
+  options {
+    memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
+  }
+}
 
 // Include common definitions from above.
 apply from: '../build.common.gradle'
 apply from: '../build.dependencies.gradle'
+
 
 android {
     namespace = 'org.firstinspires.ftc.teamcode'

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -15,23 +15,32 @@ plugins {
 }
 
 tasks.register('createResolvableReleaseCompileClasspath') {
-  configurations.create('resolvableReleaseCompileClasspath') {
-    configurations.releaseCompileClasspath.allDependencies.forEach {
-      if (it instanceof ProjectDependency) {
-        evaluationDependsOn(it.dependencyProject.path)
-      } else {
-        dependencies.add(it)
+  description = ("Creates a copy of the releaseCompileClasspath configuration"
+    + "because the original can't be resolved for some reason.")
+  doLast {
+    // Just copy all the dependencies into a new configuration
+    configurations.create('resolvableReleaseCompileClasspath') {
+      configurations.releaseCompileClasspath.allDependencies.forEach {
+        if (it instanceof ProjectDependency) {
+          evaluationDependsOn(it.dependencyProject.path)
+        } else {
+          dependencies.add(it)
+        }
       }
     }
   }
 }
-FileCollection javadocClasspath = files()
+// Populated by createJavadocClasspath, consumed by javadoc
+ext.javadocClasspath = files()
 tasks.register('createJavadocClasspath') {
-  dependsOn(tasks.createResolvableReleaseCompileClasspath)
+  dependsOn('createResolvableReleaseCompileClasspath')
+  description = ('Creates a list of dependency jar files, unpacking aar files'
+    + 'as needed, that can be used as the classpath given to javadoc.')
   doLast {
     configurations.resolvableReleaseCompileClasspath.forEach {
       String path = it.getPath()
       if (path.endsWith('aar')) {
+        // Grab classes.jar from inside aar file because javadoc can't read aar on the classpath
         javadocClasspath = (javadocClasspath
           + zipTree(path).matching(new PatternSet().include('classes.jar')))
       } else if (path.endsWith('jar')) {
@@ -43,21 +52,40 @@ tasks.register('createJavadocClasspath') {
   }
 }
 tasks.register('javadoc', Javadoc) {
-  dependsOn(tasks.createJavadocClasspath)
+  dependsOn('createJavadocClasspath')
+  description = 'Creates javadocs for the TeamCode subproject'
+  group = 'build'
   source = 'src/main/java'
   doFirst {
-    classpath = javadocClasspath
+    // The setter for classpath seems to copy the argument by value, so we have
+    // to wait until createJavadocClasspath runs to set it
+    classpath = project.ext.javadocClasspath
   }
   title = 'TeamCode'
   destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
   options {
     header = 'FTC 22047 "Tell-Tale Parts"'
+    // Document everything because we're not writing an API; these docs are for
+    // our own benefit.
     memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
+    // Makes all javadoc warnings errors, should be enabled:
     //addBooleanOption('Werror', true)
+    // Adds a 'USE' tab that finds usage of the symbol whose documentation is
+    // currently being viewed:
     addBooleanOption('use', true)
+    // Includes source code of documented symbols in javadoc. This nearly
+    // doubles the size of the generated documentation and is possibly a
+    // security risk, but this project is open source anyway and it's useful to
+    // have it handy as reference:
     //addBooleanOption('linksource', true)
+    // Lints javadoc comments. Might be enabled by default.
     addBooleanOption('Xdoclint', true)
+    // Adds links to the javadocs for RobotCore classes
     addStringOption('link', 'https://javadoc.io/doc/org.firstinspires.ftc/RobotCore/10.1.1/')
+  }
+  doLast {
+    println 'Javadoc generated at ' + destinationDir.getPath()
+    println 'Homepage: ' + destinationDir.getPath() + File.separator + 'index.html'
   }
 }
 
@@ -76,4 +104,9 @@ android {
 
 dependencies {
     implementation project(':FtcRobotController')
+}
+
+// More custom definitions!
+tasks.named('build') {
+  dependsOn('javadoc')
 }

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -16,15 +16,27 @@ plugins {
 
 tasks.register('javadoc', Javadoc) {
   source = 'src/main/java'
+  classpath = configurations.releaseCompileClasspath
+  Configuration baseConf = configurations.releaseCompileClasspath
+  //classpath = configurations.create('resolvableReleaseCompileClasspath')
+  baseConf.allDependencies.forEach {
+    if (it instanceof ProjectDependency) {
+      evaluationDependsOn(it.dependencyProject.path)
+    } else {
+      classpath.dependencies.add(it)
+    }
+  }
+  //classpath.attributes {
+    //attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'jar')
+    //attribute(BuildTypeAttr.ATTRIBUTE, 'release')
+  //}
+  classpath.resolutionStrategy {
+
+  }
   destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
   options {
     memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
   }
-  project.configurations.getByName("android-classes-directory").canBeResolved = true
-  project.configurations.getByName("android-classes-directory").forEach {
-    println it
-  }
-  failOnError = false
 }
 
 // Include common definitions from above.

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -37,6 +37,8 @@ tasks.register('createJavadocClasspath') {
   description = ('Creates a list of dependency jar files, unpacking aar files'
     + 'as needed, that can be used as the classpath given to javadoc.')
   doLast {
+    // Find jar path from each file of resolvableReleaseCompileClasspath, nontrivial because they
+    // might not all be jars.
     configurations.resolvableReleaseCompileClasspath.forEach {
       String path = it.getPath()
       if (path.endsWith('aar')) {
@@ -57,26 +59,24 @@ tasks.register('javadoc', Javadoc) {
   group = 'build'
   source = 'src/main/java'
   doFirst {
-    // The setter for classpath seems to copy the argument by value, so we have
-    // to wait until createJavadocClasspath runs to set it
+    // The setter for classpath seems to copy the argument by value, so we have to wait until
+    // createJavadocClasspath runs to set it
     classpath = project.ext.javadocClasspath
   }
   title = 'TeamCode'
   destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
   options {
     header = 'FTC 22047 "Tell-Tale Parts"'
-    // Document everything because we're not writing an API; these docs are for
-    // our own benefit.
+    // Document everything because we're not writing an API; these docs are for our own benefit.
     memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
-    // Makes all javadoc warnings errors, should be enabled:
+    // Makes all javadoc warnings errors, should be enabled
     //addBooleanOption('Werror', true)
-    // Adds a 'USE' tab that finds usage of the symbol whose documentation is
-    // currently being viewed:
+    // Adds a 'USE' tab that finds usage of the symbol whose documentation is currently being
+    // viewed
     addBooleanOption('use', true)
-    // Includes source code of documented symbols in javadoc. This nearly
-    // doubles the size of the generated documentation and is possibly a
-    // security risk, but this project is open source anyway and it's useful to
-    // have it handy as reference:
+    // Includes source code of documented symbols in javadoc. This nearly doubles the size of the
+    // generated documentation and is possibly a security risk, but this project is open source
+    // anyway and it's useful to have it handy as reference:
     //addBooleanOption('linksource', true)
     // Lints javadoc comments. Might be enabled by default.
     addBooleanOption('Xdoclint', true)

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -28,27 +28,36 @@ tasks.register('createResolvableReleaseCompileClasspath') {
 FileCollection javadocClasspath = files()
 tasks.register('createJavadocClasspath') {
   dependsOn(tasks.createResolvableReleaseCompileClasspath)
+  doLast {
     configurations.resolvableReleaseCompileClasspath.forEach {
-    String path = it.getPath()
-    if (path.endsWith('aar')) {
-      javadocClasspath = (javadocClasspath
-        + zipTree(path).matching(new PatternSet().include('classes.jar')))
-    } else if (path.endsWith('jar')) {
-      javadocClasspath = javadocClasspath + files(it)
-    } else {
-      throw new RuntimeException("Can't handle artifact type: '" + path + "'")
+      String path = it.getPath()
+      if (path.endsWith('aar')) {
+        javadocClasspath = (javadocClasspath
+          + zipTree(path).matching(new PatternSet().include('classes.jar')))
+      } else if (path.endsWith('jar')) {
+        javadocClasspath = javadocClasspath + files(it)
+      } else {
+        throw new RuntimeException("Can't handle artifact type: '" + path + "'")
+      }
     }
   }
 }
 tasks.register('javadoc', Javadoc) {
   dependsOn(tasks.createJavadocClasspath)
   source = 'src/main/java'
-  classpath = javadocClasspath
-  title = '22047 TeamCode'
+  doFirst {
+    classpath = javadocClasspath
+  }
+  title = 'TeamCode'
   destinationDir = layout.buildDirectory.dir('reports/docs').get().getAsFile()
   options {
     header = 'FTC 22047 "Tell-Tale Parts"'
     memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
+    //addBooleanOption('Werror', true)
+    addBooleanOption('use', true)
+    //addBooleanOption('linksource', true)
+    addBooleanOption('Xdoclint', true)
+    addStringOption('link', 'https://javadoc.io/doc/org.firstinspires.ftc/RobotCore/10.1.1/')
   }
 }
 

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -14,62 +14,128 @@ plugins {
   id 'checkstyle'
 }
 
-tasks.register('createResolvableReleaseCompileClasspath') {
-  description = ("Creates a copy of the releaseCompileClasspath configuration"
-    + "because the original can't be resolved for some reason.")
-  doLast {
+// Creates a copy of the releaseCompileClasspath configuration because the original can't be
+// resolved for some reason.
+def getJavadocConfig() {
+  // maybeCreate doesn't allow conditional registration
+  if (configurations.findByName('unextractedJavadocConfig') == null) {
     // Just copy all the dependencies into a new configuration
-    configurations.create('resolvableReleaseCompileClasspath') {
+    configurations.create('unextractedJavadocConfig') {
       configurations.releaseCompileClasspath.allDependencies.forEach {
         if (it instanceof ProjectDependency) {
-          evaluationDependsOn(it.dependencyProject.path)
+          evaluationDependsOn it.dependencyProject.path
         } else {
-          dependencies.add(it)
+          dependencies.add it
+        }
+      }
+    }
+  }
+  return configurations.unextractedJavadocConfig
+}
+// Creates a list of dependency jar files, unpacking aar files as needed, that can be used as the
+// classpath given to javadoc.
+def resolveJavadocConfig() {
+  // Find jar path from each file of javadocConfig, nontrivial because they might not all be
+  // jars.
+  FileCollection classpath = files()
+  getJavadocConfig().forEach {
+    String path = it.getPath()
+    if (path.endsWith('aar')) {
+      // Grab classes.jar from inside aar file because javadoc can't read aar on the classpath
+      classpath = (classpath
+        + zipTree(path).matching(new PatternSet().include('classes.jar')))
+    } else if (path.endsWith('jar')) {
+      classpath = classpath + files(it)
+    } else {
+      throw new RuntimeException("Can't handle artifact type: '" + path + "'")
+    }
+  }
+  return classpath
+}
+def getDependencyJavadocURL(Dependency dep) {
+  return 'https://javadoc.io/doc/' + dep.group + '/' + dep.name + '/' + dep.version
+}
+def getPackageListDir() {
+  return (layout.buildDirectory
+    .dir('intermediates/javadoc/package-lists')
+    .get())
+}
+def getDownloadedPackageList(Dependency dep) {
+  return (getPackageListDir()
+    .dir(dep.group + '_' + dep.name + '_' + dep.version)
+    .file('package-list')
+    .getAsFile())
+}
+tasks.register('getJavadocPackageLists') {
+  description = ("Fetches package-list files of dependencies' javadocs from javadoc.io so they can"
+    + " be linked to from ours.")
+  configure(outputs) {
+    dir getPackageListDir()
+    upToDateWhen {
+      getJavadocConfig().dependencies.every {
+        getDownloadedPackageList(it).exists()
+      }
+    }
+  }
+  doLast {
+    getJavadocConfig().dependencies.forEach {
+      File packageList = getDownloadedPackageList it
+      if (!packageList.exists()) {
+        try {
+          packageList.getParentFile().mkdirs()
+          packageList.createNewFile()
+          packageList.withOutputStream {output ->
+            boolean success = false
+            // Are we using element-list as a backup package-list in case we can't fetch it from
+            // javadoc.io? Yes, we are.
+            // Is it incorrect to use them as substitutes for each other because they're different
+            // things? Yes, it is.
+            // Does Javadoc still correctly link the external packages anyway? Yes, it does.
+            // Do we care about correctness if it works? No, we don't.
+            List<String> errs = ['/package-list', '/element-list'].stream().map(pkgListPath -> {
+              if (success) {
+                return
+              }
+              try {
+                // Download package-list for dependency
+                new URL(getDependencyJavadocURL(it) + pkgListPath).withInputStream {input ->
+                  // Synchronously pipe, then close both
+                  output << input
+                }
+                success = true
+              } catch (MalformedURLException e) {
+                throw new RuntimeException('HTTPS protocol not supported by URL constructor.')
+              } catch (IOException e) {
+                return '  Tried ' + pkgListPath + ' -- ' + e.toString()
+              } finally {
+                if (!success) {
+                  packageList.delete()
+                }
+              }
+              return "  Success. If you can see this message, file a bug report."
+            }).toList()
+            if (!success) {
+              println 'Failed to download package-list for ' + it.name + '.\n' + String.join(
+                '\n',
+                errs
+              )
+            }
+          }
+        } catch (IOException e) {
+          throw new RuntimeException('Failed to open ' + packageList + ' for writing. '
+            + e.getMessage())
         }
       }
     }
   }
 }
-// Populated by createJavadocClasspath, consumed by javadoc
-ext.javadocClasspath = files()
-tasks.register('createJavadocClasspath') {
-  dependsOn('createResolvableReleaseCompileClasspath')
-  description = ('Creates a list of dependency jar files, unpacking aar files'
-    + 'as needed, that can be used as the classpath given to javadoc.')
-  doLast {
-    // Find jar path from each file of resolvableReleaseCompileClasspath, nontrivial because they
-    // might not all be jars.
-    configurations.resolvableReleaseCompileClasspath.forEach {
-      String path = it.getPath()
-      if (path.endsWith('aar')) {
-        // Grab classes.jar from inside aar file because javadoc can't read aar on the classpath
-        javadocClasspath = (javadocClasspath
-          + zipTree(path).matching(new PatternSet().include('classes.jar')))
-      } else if (path.endsWith('jar')) {
-        javadocClasspath = javadocClasspath + files(it)
-      } else {
-        throw new RuntimeException("Can't handle artifact type: '" + path + "'")
-      }
-    }
-  }
-}
-tasks.register('getJavadocPackageLists') {
-  description = ("Fetches package-list files of dependencies' javadocs so they can be linked to"
-    + " from ours.")
-  doLast {
-
-  }
-}
 tasks.register('javadoc', Javadoc) {
-  dependsOn('createJavadocClasspath')
-  dependsOn('getJavadocPackageLists')
-  description = 'Creates javadocs for the TeamCode subproject'
+  dependsOn 'getJavadocPackageLists'
+  description = 'Generates javadocs for the TeamCode subproject'
   group = 'build'
   source = 'src/main/java'
   doFirst {
-    // The setter for classpath seems to copy the argument by value, so we have to wait until
-    // createJavadocClasspath runs to set it
-    classpath = project.ext.javadocClasspath
+    classpath = resolveJavadocConfig()
   }
   // Controls the name of the index file
   title = 'TeamCode'
@@ -78,20 +144,30 @@ tasks.register('javadoc', Javadoc) {
     // Small text in the top-right corner of the screen
     header = 'FTC 22047 "Tell-Tale Parts"'
     // Document everything because we're not writing an API; these docs are for our own benefit.
-    memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
+    showFromPrivate()
     // Makes all javadoc warnings errors, should be enabled
-    //addBooleanOption('Werror', true)
+    //addBooleanOption 'Werror', true
     // Adds a 'USE' tab that finds usage of the symbol whose documentation is currently being
     // viewed
-    addBooleanOption('use', true)
+    addBooleanOption 'use', true
     // Includes source code of documented symbols in javadoc. This nearly doubles the size of the
     // generated documentation and is possibly a security risk, but this project is open source
-    // anyway and it's useful to have it handy as reference:
-    //addBooleanOption('linksource', true)
+    // anyway and it's useful to have it handy as reference
+    //addBooleanOption 'linksource', true
     // Lints javadoc comments. Might be enabled by default.
-    addBooleanOption('Xdoclint', true)
-    // Adds links to the javadocs for RobotCore classes. TODO: use linkoffline instead
-    addStringOption('link', 'https://javadoc.io/doc/org.firstinspires.ftc/RobotCore/10.1.1/')
+    addBooleanOption 'Xdoclint', true
+  }
+  doFirst {
+    options {
+      // Adds links to the javadocs for RobotCore classes.
+      addMultilineMultiValueOption('linkoffline').setValue(
+        getJavadocConfig().dependencies.stream().filter(dep ->
+          getDownloadedPackageList(dep).exists()
+        ).map(dep ->
+          [getDependencyJavadocURL(dep), getDownloadedPackageList(dep).getParent()]
+        ).toList()
+      )
+    }
   }
   doLast {
     println 'Javadoc generated at ' + destinationDir.getPath()
@@ -105,18 +181,18 @@ apply from: '../build.dependencies.gradle'
 
 
 android {
-    namespace = 'org.firstinspires.ftc.teamcode'
+  namespace = 'org.firstinspires.ftc.teamcode'
 
-    packagingOptions {
-        jniLibs.useLegacyPackaging true
-    }
+  packagingOptions {
+    jniLibs.useLegacyPackaging true
+  }
 }
 
 dependencies {
-    implementation project(':FtcRobotController')
+  implementation project(':FtcRobotController')
 }
 
 // More custom definitions!
 tasks.named('build') {
-  dependsOn('javadoc')
+  dependsOn 'javadoc'
 }


### PR DESCRIPTION
- **Try to make javadoc Gradle task**
  Start tampering with TeamCode/build.gradle, though not really knowing what I'm doing.
- **Struggle to find what to set classpath to**
  None of the preset configurations/source file sets can be used, unfortunately. They either sound
  completely unrelated to what I want or won't resolve correctly (which is weird because they
  resolve fine during a build).
- **Struggle with configurations a bit more**
- **Get javadocs working!**
  Had to make a new configuration and copy the dependencies of the one I wanted to use. Resolving
  this gave a list of AARs and JARs, the former of which had to be unzipped to reveal the
  classes.jar file because AARs can't be put on the javadoc tool's classpath.
- **Don't do work in configuration closures**
  Use doLast instead.
- **Add task descriptions, lifecycle dep, comments**
- **Rewrap comments in build.gradle**
  Docs and maintainence stuffs
- **Start writing code to use linkoffline for javadoc**
  We want to cache fetched package-lists so we don't have to hit javadoc.io once per package per
  build. That site's giving weird errors which they blame Cloudfare for, which is all fine and well
  but it's entirely outside our control so we want to make as few requests from them as possible.
- **Use linkoffline**
  Finish up above.
