### PR TITLE
Add IntakeLayer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+gradlew text eol=lf

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.ArrayList;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.firstinspires.ftc.teamcode.layer.Layer;
@@ -164,7 +163,7 @@ public class RobotController {
      */
     public boolean update() {
         // Call all update listeners
-        for (Consumer<Boolean> listener : updateListeners) {
+        for (Runnable listener : updateListeners) {
             listener.run();
         }
 
@@ -181,7 +180,7 @@ public class RobotController {
             }
             if (!layerIter.hasNext()) {
                 // No tasks left in any layer, inform all listeners of completion
-                for (Consumer<Boolean> listener : teardownListeners) {
+                for (Runnable listener : teardownListeners) {
                     listener.run();
                 }
                 updateListeners.clear();
@@ -229,7 +228,7 @@ public class RobotController {
      * listeners are unregistered.
      * @param listener the function to be registered as an update listener
      */
-    public void addUpdateListener(Consumer<Boolean> listener) {
+    public void addUpdateListener(Runnable listener) {
         updateListeners.add(listener);
     }
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotController.java
@@ -119,10 +119,13 @@ public class RobotController {
     private static final int MAX_UNCONSUMED_REPORT_TASKS = 4;
 
     /**
-     * Listeners to fire at the start of each {@link #update} as well as after the stack has
-     * finished executing.
+     * Listeners to fire at the start of each {@link #update}.
      */
-    private ArrayList<Consumer<Boolean>> updateListeners;
+    private ArrayList<Runnable> updateListeners;
+    /**
+     * Listeners to fire during the first {@link #update} the layer stack finishes executing.
+     */
+    private ArrayList<Runnable> teardownListeners;
     /**
      * The current stack of layers and some metadata needed to execute them.
      */
@@ -162,7 +165,7 @@ public class RobotController {
     public boolean update() {
         // Call all update listeners
         for (Consumer<Boolean> listener : updateListeners) {
-            listener.accept(false);
+            listener.run();
         }
 
         // Do work on layers
@@ -178,8 +181,8 @@ public class RobotController {
             }
             if (!layerIter.hasNext()) {
                 // No tasks left in any layer, inform all listeners of completion
-                for (Consumer<Boolean> listener : updateListeners) {
-                    listener.accept(true);
+                for (Consumer<Boolean> listener : teardownListeners) {
+                    listener.run();
                 }
                 updateListeners.clear();
                 layers = null;
@@ -222,12 +225,20 @@ public class RobotController {
     /**
      * Registers a function to be called on every update.
      * Registers a function to be called on every update of the controller before layer work is
-     * performed. Listeners are executed in registration order and called with a single positional
-     * argument of true. On the first update after the topmost layer runs out of tasks, the
-     * listeners are called again with an argument of false, then unregistered.
+     * performed. Listeners are executed in registration order. After teardown,
+     * listeners are unregistered.
      * @param listener the function to be registered as an update listener
      */
     public void addUpdateListener(Consumer<Boolean> listener) {
         updateListeners.add(listener);
+    }
+    /**
+     * Registers a function to be called when the layer stack finishes executing.
+     * On the first update after the topmost layer runs out of tasks, the
+     * listeners are called in registration order, then unregistered.
+     * @param listener the function to be registered as an update listener
+     */
+    public void addTeardownListener(Runnable listener) {
+        teardownListeners.add(listener);
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Units.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Units.java
@@ -95,7 +95,7 @@ public class Units {
          */
         private final double unitsPerSecond;
 
-        time(double unitsPerSecond) {
+        Time(double unitsPerSecond) {
             this.unitsPerSecond = unitsPerSecond;
         }
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Units.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Units.java
@@ -85,9 +85,21 @@ public class Units {
         }
     }
 
+    /**
+     * Represents a unit of time.
+     */
     public static enum Time {
+        /**
+         * Seconds.
+         */
         SEC(1),
+        /**
+         * Nanoseconds.
+         */
         NANO(Math.pow(10, 9)),
+        /**
+         * Milliseconds.
+         */
         MSEC(1000);
 
         /**
@@ -95,6 +107,10 @@ public class Units {
          */
         private final double unitsPerSecond;
 
+        /**
+         * Constructs a Time enum member.
+         * @param unitsPerSecond - the number of this unit that is equivalent to one second.
+         */
         Time(double unitsPerSecond) {
             this.unitsPerSecond = unitsPerSecond;
         }
@@ -120,7 +136,13 @@ public class Units {
     public static double convert(double value, Angle fromUnit, Angle toUnit) {
         return value * toUnit.unitsPerRadian / fromUnit.unitsPerRadian;
     }
-
+    /**
+     * Converts between time units.
+     * @param value - the value in fromUnit units to convert.
+     * @param fromUnit - the unit to convert from.
+     * @param toUnit - the unit to convert to.
+     * @return the given value, converted from fromUnits to toUnits.
+     */
     public static double convert(double value, Time fromUnit, Time toUnit) {
         return value * toUnit.unitsPerSecond / fromUnit.unitsPerSecond;
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Units.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Units.java
@@ -85,6 +85,21 @@ public class Units {
         }
     }
 
+    public static enum Time {
+        SEC(1),
+        NANO(Math.pow(10, 9)),
+        MSEC(1000);
+
+        /**
+         * The number of this unit that is equivalent to one second.
+         */
+        private final double unitsPerSecond;
+
+        time(double unitsPerSecond) {
+            this.unitsPerSecond = unitsPerSecond;
+        }
+    }
+
     /**
      * Converts between distance units.
      * @param value - the value in fromUnit units to convert.
@@ -104,5 +119,9 @@ public class Units {
      */
     public static double convert(double value, Angle fromUnit, Angle toUnit) {
         return value * toUnit.unitsPerRadian / fromUnit.unitsPerRadian;
+    }
+
+    public static double convert(double value, Time fromUnit, Time toUnit) {
+        return value * toUnit.unitsPerSecond / fromUnit.unitsPerSecond;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/LayerSetupInfo.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/LayerSetupInfo.java
@@ -72,10 +72,16 @@ public class LayerSetupInfo {
     }
     /**
      * Registers a callback to be called on every update of the owning RobotController.
-     * @param listener - the callback to be called. Passed with a value of true during teardown, and
-     * false otherwise.
+     * @param listener - the callback to be called.
      */
-    public void addUpdateListener(Consumer<Boolean> listener) {
+    public void addUpdateListener(Runnable listener) {
         robotController.addUpdateListener(listener);
+    }
+    /**
+     * Registers a callback to be called after the layer stack finishes executing.
+     * @param listener - the callback to be called.
+     */
+    public void addTeardownListener(Runnable listener) {
+        robotController.addTeardownListener(listener);
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
@@ -1,7 +1,11 @@
 package org.firstinspires.ftc.teamcode.layer.input.mapping;
 
 import org.firstinspires.ftc.teamcode.layer.FunctionLayer;
+import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.task.IntakeTeleopTask;
+import org.firstinspires.ftc.teamcode.task.GamepadInputTask;
+import org.firstinspires.ftc.teamcode.task.Task;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
 
 public class TriggerIntakeMapping extends FunctionLayer {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
@@ -1,7 +1,7 @@
 package org.firstinspires.ftc.teamcode.layer.input.mapping;
 
-package org.firstinspires.ftc.teamcode.layer.FunctionLayer;
-package org.firstinspires.ftc.teamcode.task.IntakeTeleopTask;
+import org.firstinspires.ftc.teamcode.layer.FunctionLayer;
+import org.firstinspires.ftc.teamcode.task.IntakeTeleopTask;
 
 public class TriggerIntakeMapping extends FunctionLayer {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
@@ -7,6 +7,10 @@ import org.firstinspires.ftc.teamcode.task.GamepadInputTask;
 import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
 
+/**
+ * Mapping for gamepad input that uses the left and right triggers to acquire and eject samples from
+ * the intake.
+ */
 public class TriggerIntakeMapping extends FunctionLayer {
     @Override
     public void setup(LayerSetupInfo setupInfo) { }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/input/mapping/TriggerIntakeMapping.java
@@ -1,0 +1,21 @@
+package org.firstinspires.ftc.teamcode.layer.input.mapping;
+
+package org.firstinspires.ftc.teamcode.layer.FunctionLayer;
+package org.firstinspires.ftc.teamcode.task.IntakeTeleopTask;
+
+public class TriggerIntakeMapping extends FunctionLayer {
+    @Override
+    public void setup(LayerSetupInfo setupInfo) { }
+
+    @Override
+    public Task map(Task task) {
+        if (task instanceof GamepadInputTask) {
+            GamepadInputTask castedTask = (GamepadInputTask)task;
+            boolean intake = castedTask.gamepad0.triggers.left;
+            boolean eject = castedTask.gamepad0.triggers.right;
+            return new IntakeTeleopTask(false, false, (intake ? 1 : 0) - (eject ? 1 : 0));
+        } else {
+            throw new UnsupportedTaskException(this, task);
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
@@ -1,24 +1,26 @@
 package org.firstinspires.ftc.teamcode.layer.manipulator;
 
+import java.util.Iterator;
+
 import com.qualcomm.robotcore.hardware.CRServo;
 import com.qualcomm.robotcore.hardware.TouchSensor;
-import java.util.Iterator;
+
+import org.firstinspires.ftc.teamcode.Units;
 import org.firstinspires.ftc.teamcode.layer.Layer;
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.task.IntakeTask;
 import org.firstinspires.ftc.teamcode.task.IntakeTeleopTask;
 import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
-import org.firstinspires.ftc.teamcode.Units;
 
 /**
  * Controls a roller intake that can acquire, hold, and eject samples.
  */
-public class IntakeLayer implements Layer {
+public final class IntakeLayer implements Layer {
     /**
      * An action the layer can take.
      */
-    private static enum State {
+    private enum State {
         /**
          * The intake is currently attempting to acquire a sample.
          */
@@ -37,10 +39,12 @@ public class IntakeLayer implements Layer {
      * Duration in nanoseconds of intake.
      */
     private final double INTAKE_DURATION = Units.convert(1.5, Units.Time.SEC, Units.Time.NANO);
+
     /**
      * Duration in nanoseconds of ejection.
      */
     private final double EJECT_DURATION = Units.convert(1.5, Units.Time.SEC, Units.Time.NANO);
+
     /**
      * Multiplier for intake actuator power.
      * Should be in the range [-1.0, 1.0].
@@ -51,14 +55,17 @@ public class IntakeLayer implements Layer {
      * Servo spinning the intake mechanism.
      */
     private CRServo intake;
+
     /**
      * The current action the layer is taking.
      */
     private State state;
+
     /**
      * The nanosecond timestamp of the start of the last intake action.
      */
     private long intakeStart;
+
     /**
      * The nanosecond timestamp of the start of the last eject action.
      */
@@ -79,14 +86,17 @@ public class IntakeLayer implements Layer {
             }
         });
     }
+
     @Override
     public boolean isTaskDone() {
         return state == State.IDLE;
     }
+
     @Override
     public Iterator<Task> update(Iterable<Task> completed) {
         return null;
     }
+
     @Override
     public void acceptTask(Task task) {
         if (task instanceof IntakeTask) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
@@ -1,12 +1,15 @@
 package org.firstinspires.ftc.teamcode.layer.manipulator;
 
 import com.qualcomm.robotcore.hardware.DcMotor;
-import java.util.Iterable;
+import com.qualcomm.robotcore.hardware.TouchSensor;
+import java.util.Iterator;
 import org.firstinspires.ftc.teamcode.layer.Layer;
 import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
 import org.firstinspires.ftc.teamcode.task.IntakeTask;
 import org.firstinspires.ftc.teamcode.task.IntakeTeleopTask;
 import org.firstinspires.ftc.teamcode.task.Task;
+import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
+import org.firstinspires.ftc.teamcode.Units;
 
 public class IntakeLayer implements Layer {
     private static enum State {
@@ -15,6 +18,10 @@ public class IntakeLayer implements Layer {
         IDLE
     }
 
+    /**
+     * Duration in nanoseconds of intake.
+     */
+    private final double INTAKE_DURATION = Units.convert(1.5, Units.Time.SEC, Units.Time.NANO);
     /**
      * Duration in nanoseconds of ejection.
      */
@@ -35,7 +42,7 @@ public class IntakeLayer implements Layer {
         intake = setupInfo.getHardwareMap().get(DcMotor.class, "intake");
         state = State.IDLE;
         TouchSensor loadSensor = setupInfo.getHardwareMap().get(TouchSensor.class, "intake_load_sensor");
-        setup.addUpdateListener(() -> {
+        setupInfo.addUpdateListener(() -> {
             //boolean intakeDone = state == State.INTAKING && loadSensor.isPressed();
             boolean intakeDone = state == State.INTAKING && (System.nanoTime() - intakeStart) > INTAKE_DURATION;
             boolean ejectDone = state == State.EJECTING && (System.nanoTime() - ejectStart) > EJECT_DURATION;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
@@ -1,0 +1,65 @@
+package org.firstinspires.ftc.teamcode.layer.manipulator;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import java.util.Iterable;
+import org.firstinspires.ftc.teamcode.layer.Layer;
+import org.firstinspires.ftc.teamcode.layer.LayerSetupInfo;
+import org.firstinspires.ftc.teamcode.task.IntakeTask;
+import org.firstinspires.ftc.teamcode.task.IntakeTeleopTask;
+import org.firstinspires.ftc.teamcode.task.Task;
+
+public class IntakeLayer implements Layer {
+    /**
+     * Duration in nanoseconds of ejection.
+     */
+    private final double EJECT_DURATION = Units.convert(1.5, Units.Time.SEC, Units.Time.NANO);
+
+    private final double INTAKE_SPEED = 1.0;
+
+    /**
+     * Motor spinning the intake mechanism.
+     */
+    private DcMotor intake;
+    private boolean isIntaking;
+    private boolean isEjecting;
+    private long ejectStart;
+
+    @Override
+    public void setup(LayerSetupInfo setupInfo) {
+        intake = setupInfo.getHardwareMap().get(DcMotor.class, "intake");
+        TouchSensor loadSensor = setupInfo.getHardwareMap().get(TouchSensor.class, "intake_load_sensor");
+        setup.addUpdateListener(() -> {
+            if (isIntaking && loadSensor.isPressed()) {
+                isIntaking = false;
+                intake.setPower(0);
+            } else if (isEjecting && (System.nanoTime() - ejectStart) > EJECT_DURATION) {
+                isEjecting = false;
+                intake.setPower(0);
+            }
+        });
+    }
+    @Override
+    public boolean isTaskDone() {
+        return !(isIntaking || isEjecting);
+    }
+    @Override
+    public Iterator<Task> update(Iterable<Task> completed) {
+        return null;
+    }
+    @Override
+    public void acceptTask(Task task) {
+        if (task instanceof IntakeTask) {
+            IntakeTask castedTask = (IntakeTask)task;
+            if (castedTask.intake) {
+                isIntaking = true;
+                intake.setPower(-INTAKE_SPEED);
+            }
+            if (castedTask.eject) {
+                isEjecting = true;
+                intake.setPower(INTAKE_SPEED);
+            }
+        } else if (task instanceof IntakeTeleopTask) {
+            IntakeTeleopTask castedTask = (IntakeTeleopTask)task;
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
@@ -11,10 +11,25 @@ import org.firstinspires.ftc.teamcode.task.Task;
 import org.firstinspires.ftc.teamcode.task.UnsupportedTaskException;
 import org.firstinspires.ftc.teamcode.Units;
 
+/**
+ * Controls a roller intake that can acquire, hold, and eject samples.
+ */
 public class IntakeLayer implements Layer {
+    /**
+     * An action the layer can take.
+     */
     private static enum State {
+        /**
+         * The intake is currently attempting to acquire a sample.
+         */
         INTAKING,
+        /**
+         * The intake is currently ejecting a sample.
+         */
         EJECTING,
+        /**
+         * The intake is idle.
+         */
         IDLE
     }
 
@@ -26,15 +41,27 @@ public class IntakeLayer implements Layer {
      * Duration in nanoseconds of ejection.
      */
     private final double EJECT_DURATION = Units.convert(1.5, Units.Time.SEC, Units.Time.NANO);
-
+    /**
+     * Multiplier for intake actuator power.
+     * Should be in the range [-1.0, 1.0].
+     */
     private final double INTAKE_SPEED = 1.0;
 
     /**
      * Servo spinning the intake mechanism.
      */
     private CRServo intake;
+    /**
+     * The current action the layer is taking.
+     */
     private State state;
+    /**
+     * The nanosecond timestamp of the start of the last intake action.
+     */
     private long intakeStart;
+    /**
+     * The nanosecond timestamp of the start of the last eject action.
+     */
     private long ejectStart;
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
@@ -1,6 +1,6 @@
 package org.firstinspires.ftc.teamcode.layer.manipulator;
 
-import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.CRServo;
 import com.qualcomm.robotcore.hardware.TouchSensor;
 import java.util.Iterator;
 import org.firstinspires.ftc.teamcode.layer.Layer;
@@ -30,18 +30,18 @@ public class IntakeLayer implements Layer {
     private final double INTAKE_SPEED = 1.0;
 
     /**
-     * Motor spinning the intake mechanism.
+     * Servo spinning the intake mechanism.
      */
-    private DcMotor intake;
+    private CRServo intake;
     private State state;
     private long intakeStart;
     private long ejectStart;
 
     @Override
     public void setup(LayerSetupInfo setupInfo) {
-        intake = setupInfo.getHardwareMap().get(DcMotor.class, "intake");
+        intake = setupInfo.getHardwareMap().get(CRServo.class, "intake");
         state = State.IDLE;
-        TouchSensor loadSensor = setupInfo.getHardwareMap().get(TouchSensor.class, "intake_load_sensor");
+        //TouchSensor loadSensor = setupInfo.getHardwareMap().get(TouchSensor.class, "intake_load_sensor");
         setupInfo.addUpdateListener(() -> {
             //boolean intakeDone = state == State.INTAKING && loadSensor.isPressed();
             boolean intakeDone = state == State.INTAKING && (System.nanoTime() - intakeStart) > INTAKE_DURATION;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/IntakeLayer.java
@@ -14,6 +14,7 @@ public class IntakeLayer implements Layer {
         EJECTING,
         IDLE
     }
+
     /**
      * Duration in nanoseconds of ejection.
      */
@@ -32,21 +33,21 @@ public class IntakeLayer implements Layer {
     @Override
     public void setup(LayerSetupInfo setupInfo) {
         intake = setupInfo.getHardwareMap().get(DcMotor.class, "intake");
-        state = IDLE;
+        state = State.IDLE;
         TouchSensor loadSensor = setupInfo.getHardwareMap().get(TouchSensor.class, "intake_load_sensor");
         setup.addUpdateListener(() -> {
-            //boolean intakeDone = state == INTAKING && loadSensor.isPressed();
-            boolean intakeDone = state == INTAKING && (System.nanoTime() - intakeStart) > INTAKE_DURATION;
-            boolean ejectDone = state == EJECTING && (System.nanoTime() - ejectStart) > EJECT_DURATION;
+            //boolean intakeDone = state == State.INTAKING && loadSensor.isPressed();
+            boolean intakeDone = state == State.INTAKING && (System.nanoTime() - intakeStart) > INTAKE_DURATION;
+            boolean ejectDone = state == State.EJECTING && (System.nanoTime() - ejectStart) > EJECT_DURATION;
             if (intakeDone || ejectDone) {
-                state = IDLE;
+                state = State.IDLE;
                 intake.setPower(0);
             }
         });
     }
     @Override
     public boolean isTaskDone() {
-        return state == IDLE;
+        return state == State.IDLE;
     }
     @Override
     public Iterator<Task> update(Iterable<Task> completed) {
@@ -57,26 +58,26 @@ public class IntakeLayer implements Layer {
         if (task instanceof IntakeTask) {
             IntakeTask castedTask = (IntakeTask)task;
             if (castedTask.acquire) {
-                state = INTAKING;
+                state = State.INTAKING;
                 intake.setPower(-INTAKE_SPEED);
                 intakeStart = System.nanoTime();
             } else if (castedTask.eject) {
-                state = EJECTING;
+                state = State.EJECTING;
                 intake.setPower(INTAKE_SPEED);
                 ejectStart = System.nanoTime();
             }
         } else if (task instanceof IntakeTeleopTask) {
             IntakeTeleopTask castedTask = (IntakeTeleopTask)task;
             if (castedTask.acquire) {
-                state = INTAKING;
+                state = State.INTAKING;
                 intake.setPower(-INTAKE_SPEED);
                 intakeStart = System.nanoTime();
             } else if (castedTask.timedEject) {
-                state = EJECTING;
+                state = State.EJECTING;
                 intake.setPower(INTAKE_SPEED);
                 ejectStart = System.nanoTime();
             } else {
-                state = IDLE;
+                state = State.IDLE;
                 intakeStart = 0;
                 ejectStart = 0;
                 intake.setPower(castedTask.intakePower);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/layer/manipulator/LiftLayer.java
@@ -92,8 +92,8 @@ public class LiftLayer implements Layer {
         raising = false;
         goalAchieved = true;
         deltaHistory = new CircularBuffer<>(DELTA_HISTORY_COUNT);
-        setupInfo.addUpdateListener((isTeardown) -> {
-            if (zeroSwitch.isPressed() && !isTeardown) {
+        setupInfo.addUpdateListener(() -> {
+            if (zeroSwitch.isPressed()) {
                 zeroDist = pulley.getDistance();
             }
         });

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
@@ -9,11 +9,12 @@ public class IntakeTask {
      * Depending on the intake implementation, this may be a simple delay or rely on a sensor to
      * detect a sample.
      */
-    public final boolean acquire;
+    private final boolean acquire;
+
     /**
      * Whether the intake should run until a sample has been predicted to be ejected.
      */
-    public final boolean eject;
+    private final boolean eject;
 
     /**
      * Constructs an IntakeTask.
@@ -30,5 +31,25 @@ public class IntakeTask {
                 "Cannot direct the intake to simultaneously acquire a sample and eject one."
             );
         }
+    }
+
+    /**
+     * Returns whether the intake should run until a sample has been predicted to be acquired.
+     * Depending on the intake implementation, this may be a simple delay or rely on a sensor to
+     * detect a sample.
+     *
+     * @return whether the intake should run until a sample has been predicted to be acquired.
+     */
+    public final boolean getAcquire() {
+        return acquire;
+    }
+
+    /**
+     * Returns whether the intake should run until a sample has been predicted to be ejected.
+     *
+     * @return whether the intake should run until a sample has been predicted to be ejected.
+     */
+    public final boolean getEject() {
+        return eject;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
@@ -1,9 +1,27 @@
 package org.firstinspires.ftc.teamcode.task;
 
+/**
+ * Controls the sample intake.
+ */
 public class IntakeTask {
+    /**
+     * Whether the intake should run until a sample has been predicted to be acquired.
+     * Depending on the intake implementation, this may be a simple delay or rely on a sensor to
+     * detect a sample.
+     */
     public final boolean acquire;
+    /**
+     * Whether the intake should run until a sample has been predicted to be ejected.
+     */
     public final boolean eject;
 
+    /**
+     * Constructs an IntakeTask.
+     * @param acquire - whether the intake should run until a sample has been predicted to be
+     * acquired. Incompatible with eject.
+     * @param eject - whether the intake should run until a sample has been predicted to be
+     * ejected. Incompatible with acquire.
+     */
     public IntakeTask(boolean acquire, boolean eject) {
         this.acquire = acquire;
         this.eject = eject;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
@@ -1,0 +1,15 @@
+package org.firstinspires.ftc.teamcode.task;
+
+public class IntakeTask {
+    public final boolean acquire;
+    public final boolean eject;
+
+    public IntakeTask(boolean acquire, boolean eject) {
+        this.acquire = acquire;
+        this.eject = eject;
+        if (acquire && eject) {
+            throw new IllegalArgumentException(
+                "Cannot direct the intake to simultaneously acquire a sample and eject one."
+            );
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTask.java
@@ -11,5 +11,6 @@ public class IntakeTask {
             throw new IllegalArgumentException(
                 "Cannot direct the intake to simultaneously acquire a sample and eject one."
             );
+        }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
@@ -1,10 +1,34 @@
 package org.firstinspires.ftc.teamcode.task;
 
+/**
+ * Controls the intake in teleop.
+ */
 public class IntakeTeleopTask implements Task {
+    /**
+     * Whether the intake should run until a sample has been predicted to be acquired.
+     * Depending on the intake implementation, this may be a simple delay or rely on a sensor to
+     * detect a sample.
+     */
     public final boolean acquire;
+    /**
+     * Whether the intake should run until a sample has been predicted to be ejected.
+     * This runs on a simple delay.
+     */
     public final boolean timedEject;
+    /**
+     * A power to directly give to the intake actuator.
+     */
     public final double intakePower;
 
+    /**
+     * Constructs an IntakeTeleopTask.
+     * @param acquire - whether the intake should run until a sample has been predicted to be
+     * acquired. Incompatible with timedEject.
+     * @param timedEject - whether the intake should run until a sample has been predicted to be
+     * ejected. Incompatible with acquire.
+     * @param intakePower - a power to directly give to the intake actuator. Ignored if acquire or
+     * timedEject are set.
+     */
     public IntakeTeleopTask(boolean acquire, boolean timedEject, double intakePower) {
         this.acquire = acquire;
         this.timedEject = timedEject;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
@@ -1,6 +1,6 @@
 package org.firstinspires.ftc.teamcode.task;
 
-public class IntakeTeleopTask {
+public class IntakeTeleopTask implements Task {
     public final boolean acquire;
     public final boolean timedEject;
     public final double intakePower;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
@@ -9,19 +9,22 @@ public class IntakeTeleopTask implements Task {
      * Depending on the intake implementation, this may be a simple delay or rely on a sensor to
      * detect a sample.
      */
-    public final boolean acquire;
+    private final boolean acquire;
+
     /**
      * Whether the intake should run until a sample has been predicted to be ejected.
      * This runs on a simple delay.
      */
-    public final boolean timedEject;
+    private final boolean timedEject;
+
     /**
      * A power to directly give to the intake actuator.
      */
-    public final double intakePower;
+    private final double intakePower;
 
     /**
      * Constructs an IntakeTeleopTask.
+     *
      * @param acquire - whether the intake should run until a sample has been predicted to be
      * acquired. Incompatible with timedEject.
      * @param timedEject - whether the intake should run until a sample has been predicted to be
@@ -38,5 +41,35 @@ public class IntakeTeleopTask implements Task {
                 "Cannot direct the intake to simultaneously acquire a sample and eject one."
             );
         }
+    }
+
+    /**
+     * Returns whether the intake should run until a sample has been predicted to be acquired.
+     * Depending on the intake implementation, this may be a simple delay or rely on a sensor to
+     * detect a sample.
+     *
+     * @return whether the intake should run until a sample has been predicted to be acquired.
+     */
+    public final boolean getAcquire() {
+        return acquire;
+    }
+
+    /**
+     * Returns whether the intake should run until a sample has been predicted to be ejected.
+     * This runs on a simple delay.
+     *
+     * @return whether the intake should run until a sample has been predicted to be ejected.
+     */
+    public final boolean getTimedEject() {
+        return timedEject;
+    }
+
+    /**
+     * Returns a power to directly give to the intake actuator.
+     *
+     * @return a power to directly give to the intake actuator, which will be in the range [-1, 1].
+     */
+    public final double getIntakePower() {
+        return intakePower;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
@@ -1,13 +1,18 @@
 package org.firstinspires.ftc.teamcode.task;
 
-public class IntakeTask {
+public class IntakeTeleopTask {
     public final boolean acquire;
     public final boolean timedEject;
     public final double intakePower;
 
-    public IntakeTask(boolean acquire, boolean timedEject, double intakePower) {
+    public IntakeTeleopTask(boolean acquire, boolean timedEject, double intakePower) {
         this.acquire = acquire;
         this.timedEject = timedEject;
         this.intakePower = intakePower;
+        if (acquire && timedEject) {
+            throw new IllegalArgumentException(
+                "Cannot direct the intake to simultaneously acquire a sample and eject one."
+            );
+        }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/task/IntakeTeleopTask.java
@@ -1,0 +1,13 @@
+package org.firstinspires.ftc.teamcode.task;
+
+public class IntakeTask {
+    public final boolean acquire;
+    public final boolean timedEject;
+    public final double intakePower;
+
+    public IntakeTask(boolean acquire, boolean timedEject, double intakePower) {
+        this.acquire = acquire;
+        this.timedEject = timedEject;
+        this.intakePower = intakePower;
+    }
+}


### PR DESCRIPTION
- **Split updateListener into update and teardownListener**
  Making update listeners Consumer\<Boolean\> so they can also handle teardown is unnecessarily
  complicated for such a rare use-case, and there's really no reason for the same listeners to
  handle both events anyway. Responding to teardown has been shifted to a new kind of listener,
  while both kinds of listeners are now simple Runnables.
- **Enforce LF endings for gradlew sh script**
  Change .gitattributes so we can stop running dos2unix every time we check out code on a Cygwin
  machine.
- **Write IntakeLayer, add time to Units**
  Add IntakeLayer to control the sample intake roller.
  Add time units to Units.
- **Maybe finish intake**
- **Add intake mapping and finish intake tasks**
- **Fix some build errors**
- **Fix all build errors**
- **Change intake from DcMotor to CRServo**
  The code looks almost identical because only methods from DcMotor and CRServo's common interface
  (SimpleDcMotor) were used. This kind of change isn't frequent enough to warrant going through the
  codebase and changing motor types to SimpleDcMotor.
