### PR TITLE
Add pre-commit and pre-push hooks

### DIFF
--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,18 @@
+if test -d hooks
+then
+  cd hooks
+fi
+ts=`date +%s`
+for hook in *
+do
+  case $hook in
+    install*)
+      ;;
+    *)
+      dst=../.git/hooks/$hook
+      mv $dst $dst.old-$ts 2>/dev/null
+      cp $hook $dst
+      chmod a+x $dst
+      ;;
+  esac
+done

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -3,7 +3,17 @@ if test -d hooks
 then
   cd hooks
 fi
-ts=`date +%s`
+case $1 in
+  -c|--clobber)
+    ;;
+  '')
+    ts=`date +%s`
+    ;;
+  *)
+    echo Unrecognized argument $1. >2
+    exit 1
+    ;;
+esac
 for hook in *
 do
   case $hook in
@@ -11,7 +21,10 @@ do
       ;;
     *)
       dst=../.git/hooks/$hook
-      mv $dst $dst.old-$ts 2>/dev/null
+      if test $ts
+      then
+        mv $dst $dst.old-$ts 2>/dev/null
+      fi
       cp $hook $dst
       chmod a+x $dst
       ;;

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 if test -d hooks
 then
   cd hooks

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,2 @@
+# Checks for whitespace "errors" (trailing line whitespace, usually) and merge conflict markers
+exec git diff-index --check --cached HEAD --

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,2 +1,3 @@
+#!/bin/sh
 # Checks for whitespace "errors" (trailing line whitespace, usually) and merge conflict markers
 exec git diff-index --check --cached HEAD --

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -6,6 +6,10 @@ git reset --hard --quiet
 
 while read lref _ _ robj
 do
+  if test $lref = '(deleted)'
+  then
+    continue
+  fi
   git checkout --quiet $lref --
   echo Testing $lref...
   if test $robj = $zero

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,11 +1,10 @@
 #!/bin/sh
-set -x
 echo Starting pre-push checks...
 # Save index, working tree, and current branch (if we are on one) so we can check it out again
 # later. We have to use name-rev to get a ref name if possible because checkout will leave us
 # detached if we give a commit id, even if that id is pointed to by a ref.
 stash=`git stash create`
-head=`git name-rev --name-only HEAD`
+head=`git name-rev --refs='refs/heads/*' --name-only HEAD`
 
 on_exit ()
 {
@@ -27,12 +26,12 @@ zero=`echo $null | tr '[0-9a-f]' '0'`
 git reset --hard --quiet
 # Make sure our local repo is aware of all possible robjs in case we use them for diff-index. Has
 # the side effect of printing ls-remote, so to save a network call we also grab the remote HEAD from
-# here (used as a fallback robj)
+# here (used as a fallback robj).
+# Note that fetch-pack is a networking operation and may fail--if it does, nothing will be written
+# to stdout and the result of this pipeline will be empty. This is fine; if robj is zero then we'll
+# just compare against null for diff-index instead of rhead.
 echo Fetching objects from \"$2\"...
-git fetch-pack --all --no-progress $2
 rhead=`git fetch-pack --all --no-progress $2 2>&1 | grep -m1 ' HEAD' | cut -f1 -d' '`
-echo null=$null
-echo rhead=$rhead
 
 # lref = local ref being pushed, lobj = object pointed to by lref
 # rref = remote ref being pushed to, robj = object pointed to by robj
@@ -54,20 +53,15 @@ do
     # (so check all files with diff-index)
     robj=${rhead:-$null}
   fi
-  echo Chose robj=$robj
-  echo null=$null
-  echo rhead=$rhead
   # Check for whitespace errors and merge conflict markers
   git diff-index --check --cached $robj -- || {
     echo Branch $lref failed diff-index --check. >&2
-    git checkout --quiet $head --
     exit 1
   }
   echo Passed diff-index --check.
   # Assemble and run all Gradle checks
   ./gradlew build || {
     echo Branch $lref failed to build. >&2
-    git checkout --quiet $head --
     exit 1
   }
   echo Successfully ran Gradle build.
@@ -75,5 +69,4 @@ done
 
 echo Pre-push checks done.
 
-exit 1
 exit 0

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,42 +1,79 @@
 #!/bin/sh
+set -x
+echo Starting pre-push checks...
+# Save index, working tree, and current branch (if we are on one) so we can check it out again
+# later. We have to use name-rev to get a ref name if possible because checkout will leave us
+# detached if we give a commit id, even if that id is pointed to by a ref.
 stash=`git stash create`
 head=`git name-rev --name-only HEAD`
-zero=`git hash-object --stdin </dev/null | tr '[0-9a-f]' '0'`
-git reset --hard --quiet
 
+on_exit ()
+{
+  # Checkout the branch or commit that was checked out before
+  git checkout --quiet $head --
+  # Restore the index and working tree from before
+  if test $stash
+  then
+    git stash apply --index --quiet $stash
+  fi
+}
+trap on_exit EXIT
+
+# Get the hash of a null tree
+null=`git hash-object -t tree /dev/null`
+# Get an appropriate length zero hash
+zero=`echo $null | tr '[0-9a-f]' '0'`
+# Reset index and working tree so checkout doesn't complain
+git reset --hard --quiet
+# Make sure our local repo is aware of all possible robjs in case we use them for diff-index. Has
+# the side effect of printing ls-remote, so to save a network call we also grab the remote HEAD from
+# here (used as a fallback robj)
+echo Fetching objects from \"$2\"...
+git fetch-pack --all --no-progress $2
+rhead=`git fetch-pack --all --no-progress $2 2>&1 | grep -m1 ' HEAD' | cut -f1 -d' '`
+echo null=$null
+echo rhead=$rhead
+
+# lref = local ref being pushed, lobj = object pointed to by lref
+# rref = remote ref being pushed to, robj = object pointed to by robj
 while read lref _ _ robj
 do
   if test $lref = '(deleted)'
   then
+    # Nothing to check for deleted refs
     continue
   fi
+  # Check out the local ref, making sure to treat it as a ref and not a file name
   git checkout --quiet $lref --
   echo Testing $lref...
+  # We want to use robj to run the diff-index check against, but if rref doesn't exist (like when
+  # pushing a new branch) then it'll be invalid
   if test $robj = $zero
   then
-    robj=`git ls-remote $1 HEAD | head -1 | cut -f1`
-    if test -z $robj
-    then
-      robj=`git hash-object -t tree /dev/null`
-    fi
+    # Try to check against the remote head, but if one isn't set just check against the null tree
+    # (so check all files with diff-index)
+    robj=${rhead:-$null}
   fi
+  echo Chose robj=$robj
+  echo null=$null
+  echo rhead=$rhead
+  # Check for whitespace errors and merge conflict markers
   git diff-index --check --cached $robj -- || {
     echo Branch $lref failed diff-index --check. >&2
     git checkout --quiet $head --
     exit 1
   }
+  echo Passed diff-index --check.
+  # Assemble and run all Gradle checks
   ./gradlew build || {
     echo Branch $lref failed to build. >&2
     git checkout --quiet $head --
     exit 1
   }
+  echo Successfully ran Gradle build.
 done
 
-git checkout --quiet $head --
-if test $stash
-then
-  git stash apply --index --quiet $stash
-fi
 echo Pre-push checks done.
 
+exit 1
 exit 0

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -14,7 +14,11 @@ do
   echo Testing $lref...
   if test $robj = $zero
   then
-    robj=`git hash-object -t tree /dev/null`
+    robj=`git ls-remote $1 HEAD | head -1 | cut -f1`
+    if test -z $robj
+    then
+      robj=`git hash-object -t tree /dev/null`
+    fi
   fi
   git diff-index --check --cached $robj -- || {
     echo Branch $lref failed diff-index --check. >&2

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,32 @@
+#!/bin/sh
+stash=`git stash create`
+head=`git name-rev --name-only HEAD`
+zero=`git hash-object --stdin </dev/null | tr '[0-9a-f]' '0'`
+git reset --hard --quiet
+
+while read lref _ _ robj
+do
+  git checkout --quiet $lref --
+  echo Testing $lref...
+  if test $robj = $zero
+  then
+    robj=`git hash-object -t tree /dev/null`
+  fi
+  git diff-index --check --cached $robj -- || {
+    echo Branch $lref failed diff-index --check. >&2
+    exit 1
+  }
+  ./gradlew build || {
+    echo Branch $lref failed to build. >&2
+    exit 1
+  }
+done
+
+git checkout --quiet $head --
+if test $stash
+then
+  git stash apply --index --quiet $stash
+fi
+echo Pre-push checks done.
+
+exit 0

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -14,10 +14,12 @@ do
   fi
   git diff-index --check --cached $robj -- || {
     echo Branch $lref failed diff-index --check. >&2
+    git checkout --quiet $head --
     exit 1
   }
   ./gradlew build || {
     echo Branch $lref failed to build. >&2
+    git checkout --quiet $head --
     exit 1
   }
 done


### PR DESCRIPTION
- **Add hooks and install script**
  Add hooks directory, whose contents are copied into .git/hooks by install.sh. I'm not sure whether
  developers on Windows will need a batch file for this, or if running Git Bash is enough.
- **Checkout original branch on abend**
  Fix bug where a failed push check would cause the head to detach on the first ref whose check
  failed.
- **Tweak pre-push hook**
  Handle special case for deleted source refs in push hook.
