### PR TITLE
Fix deleted branch detection in pre-push

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -37,7 +37,7 @@ rhead=`git fetch-pack --all --no-progress $2 2>&1 | grep -m1 ' HEAD' | cut -f1 -
 # rref = remote ref being pushed to, robj = object pointed to by robj
 while read lref _ _ robj
 do
-  if test $lref = '(deleted)'
+  if test $lref = '(delete)'
   then
     # Nothing to check for deleted refs
     continue


### PR DESCRIPTION
The pre-push hook obviously can't build a deleted branch, so we're supposed to skip these. Because
the script checked lref against (deleted), it would interpret the actual deleted branch placeholder
of (delete) as a branch name that could be checked out and built.
